### PR TITLE
비밀번호 재설정 이메일 전송화면, 비밀번호 재설정UI 추가

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/src/app/password-forget/page.tsx
+++ b/src/app/password-forget/page.tsx
@@ -1,0 +1,11 @@
+import PasswordForgetForm from "@/components/auth/PasswordForget/PasswordForgetForm";
+
+const PasswordForgetPage = () => {
+  return (
+    <div className="flex justify-center items-center">
+      <PasswordForgetForm />
+    </div>
+  );
+};
+
+export default PasswordForgetPage;

--- a/src/app/password-reset/PasswordResetPageClient.tsx
+++ b/src/app/password-reset/PasswordResetPageClient.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import PasswordResetForm from "@/components/auth/PasswordReset/PasswordResetForm";
+import { useSearchParams } from "next/navigation";
+
+export default function PasswordResetPageClient() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
+  if (!token || typeof token !== "string") {
+    return <div className="text-center py-10">잘못된 접근입니다.</div>;
+  }
+
+  return (
+    <div className="flex justify-center items-center">
+      <PasswordResetForm token={token} />
+    </div>
+  );
+}

--- a/src/app/password-reset/page.tsx
+++ b/src/app/password-reset/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from "react";
+import PasswordResetPageClient from "./PasswordResetPageClient";
+
+export default function Page() {
+  return (
+    <Suspense fallback={<div className="text-center py-10">로딩 중...</div>}>
+      <PasswordResetPageClient />
+    </Suspense>
+  );
+}

--- a/src/components/auth/LoginForm/LoginForm.tsx
+++ b/src/components/auth/LoginForm/LoginForm.tsx
@@ -76,7 +76,7 @@ const LoginForm = () => {
         {/* 비밀번호 재설정 */}
         <div className="flex justify-center text-sm text-gray600 font-light">
           <Link
-            href="/forgot-password"
+            href="/password-forget"
             className="underline hover:opacity-80 transition"
           >
             비밀번호 재설정

--- a/src/components/auth/PasswordForget/PasswordForgetForm.tsx
+++ b/src/components/auth/PasswordForget/PasswordForgetForm.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import React from "react";
+import TextInput from "@/components/common/Input/TextInput";
+import BaseButton from "@/components/common/Button/BaseButton";
+import useForgotPasswordForm from "./usePasswordForgetForm";
+import Link from "next/link";
+import { LogoIcon } from "@/components/common/Icons";
+
+const PasswordForgetForm = () => {
+  const { email, emailError, isLoading, handleEmailChange, handleSubmit } =
+    useForgotPasswordForm();
+
+  return (
+    <div className="w-full max-w-[430px] border border-violet300 mt-32">
+      <div className="flex justify-center items-center pt-8 pb-4 gap-4">
+        <div className="flex justify-center items-center gap-4 text-2xl font-semibold text-violet800">
+          <LogoIcon />
+          <h1>ZARO</h1>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-5 px-6 sm:px-12 py-6">
+        <form onSubmit={handleSubmit} className="flex flex-col  gap-5">
+          <h2 className="text-xl text-gray900 text-center">비밀번호 재설정</h2>
+          <h3 className="text-sm text-gray900 text-center leading-loose">
+            가입한 이메일 주소를 입력해주세요
+            <br />
+            이메일 인증 완료 후 비밀번호를 재설정할 수 있습니다.
+          </h3>
+
+          <TextInput
+            placeholder="이메일을 입력하세요"
+            value={email}
+            onChange={handleEmailChange}
+            error={emailError}
+            size="xl"
+          />
+          <BaseButton
+            type="submit"
+            color="violet800"
+            size="xl"
+            isLoading={isLoading}
+          >
+            인증 메일 전송
+          </BaseButton>
+          <div className="flex justify-center text-sm text-gray600 font-light">
+            <Link
+              href="/login"
+              className="underline hover:opacity-80 transition"
+            >
+              로그인으로 돌아가기
+            </Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default PasswordForgetForm;

--- a/src/components/auth/PasswordForget/usePasswordForgetForm.ts
+++ b/src/components/auth/PasswordForget/usePasswordForgetForm.ts
@@ -1,0 +1,55 @@
+import { validateEmail } from "@/utils/validate";
+import { ChangeEvent, FormEvent, useCallback, useState } from "react";
+
+const useForgotPasswordForm = () => {
+  const [email, setEmail] = useState("");
+  const [emailError, setEmailError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const validateForm = useCallback(() => {
+    const error = validateEmail(email);
+    if (error) {
+      setEmailError(error);
+      return false;
+    }
+    setEmailError("");
+    return true;
+  }, [email]);
+
+  const handleEmailChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      setEmail(e.target.value);
+      if (emailError) setEmailError("");
+    },
+    [emailError],
+  );
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!validateForm()) return;
+
+    setIsLoading(true);
+    // try {
+    // 	await forgotPassword(email);
+    // 	alert("비밀번호 재설정 메일이 발송되었습니다.");
+    // } catch (err) {
+    // 	if (err instanceof Error) {
+    // 		alert(err.message);
+    // 	} else {
+    // 		alert("알 수 없는 오류가 발생했습니다.");
+    // 	}
+    // } finally {
+    // 	setIsLoading(false);
+    // }
+  };
+
+  return {
+    email,
+    emailError,
+    isLoading,
+    handleEmailChange,
+    handleSubmit,
+  };
+};
+
+export default useForgotPasswordForm;

--- a/src/components/auth/PasswordReset/PasswordResetForm.tsx
+++ b/src/components/auth/PasswordReset/PasswordResetForm.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import BaseButton from "@/components/common/Button/BaseButton";
+import Link from "next/link";
+import PasswordInput from "@/components/common/Input/PasswordInput";
+import usePasswordResetForm from "./usePasswordResetForm";
+import { LogoIcon } from "@/components/common/Icons";
+
+interface PasswordResetFormProps {
+  token: string;
+}
+
+const PasswordResetForm = ({ token }: PasswordResetFormProps) => {
+  const {
+    formState,
+    errors,
+    isLoading,
+    handleFormChange,
+    handleResetPassword,
+  } = usePasswordResetForm(token);
+
+  return (
+    <div className="w-full max-w-[430px] border border-violet300 mt-32">
+      <div className="flex justify-center items-center pt-8 pb-4 gap-4">
+        <div className="flex justify-center items-center gap-4 text-2xl font-semibold text-violet800">
+          <LogoIcon />
+          <h1>ZARO</h1>
+        </div>
+      </div>
+      <div className="flex flex-col gap-5 px-6 sm:px-12 py-6">
+        <form onSubmit={handleResetPassword} className="flex flex-col gap-5">
+          <h2 className="text-xl text-gray900 text-center">비밀번호 재설정</h2>
+          <h3 className="text-sm text-gray900 text-center leading-loose">
+            새로운 비밀번호를 설정하세요.
+          </h3>
+
+          <PasswordInput
+            placeholder="비밀번호를 입력하세요."
+            size="xl"
+            value={formState.password}
+            onChange={handleFormChange("password")}
+            styleState={errors.password ? "invalid" : "default"}
+            error={errors.password}
+          />
+          <PasswordInput
+            placeholder="비밀번호 확인"
+            size="xl"
+            value={formState.passwordConfirm}
+            onChange={handleFormChange("passwordConfirm")}
+            styleState={errors.passwordConfirm ? "invalid" : "default"}
+            error={errors.passwordConfirm}
+          />
+          <BaseButton
+            type="submit"
+            color="violet800"
+            size="xl"
+            isLoading={isLoading}
+          >
+            확인
+          </BaseButton>
+          <div className="flex justify-center text-sm text-gray600 font-light">
+            <Link
+              href="/login"
+              className="underline hover:opacity-80 transition"
+            >
+              로그인으로 돌아가기
+            </Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default PasswordResetForm;

--- a/src/components/auth/PasswordReset/usePasswordResetForm.ts
+++ b/src/components/auth/PasswordReset/usePasswordResetForm.ts
@@ -1,0 +1,74 @@
+import { validatePassword } from "@/utils/validate";
+import { useRouter } from "next/navigation";
+import { ChangeEvent, FormEvent, useCallback, useState } from "react";
+
+type FormType = "password" | "passwordConfirm";
+
+interface PasswordResetErrors {
+  password?: string;
+  passwordConfirm?: string;
+}
+
+const usePasswordResetForm = (token: string) => {
+  const router = useRouter();
+  const [formState, setFormState] = useState({
+    password: "",
+    passwordConfirm: "",
+  });
+  const [errors, setErrors] = useState<PasswordResetErrors>({});
+  const [isLoading, setIsLoading] = useState(false);
+
+  const validateForm = useCallback(() => {
+    const newErrors: PasswordResetErrors = {};
+
+    const passwordError = validatePassword(formState.password);
+    if (passwordError) newErrors.password = passwordError;
+
+    if (formState.password !== formState.passwordConfirm) {
+      newErrors.passwordConfirm = "비밀번호가 다릅니다.";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }, [formState.password, formState.passwordConfirm]);
+
+  const handleFormChange = useCallback(
+    (key: FormType) => (e: ChangeEvent<HTMLInputElement>) => {
+      const { value } = e.target;
+      setFormState((prev) => ({ ...prev, [key]: value }));
+      setErrors((prev) => ({ ...prev, [key]: "" }));
+    },
+    [],
+  );
+
+  const handleResetPassword = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!validateForm()) return;
+
+    setIsLoading(true);
+    console.log(token);
+    // try {
+    //   await resetPassword(token, formState.password);
+    //   alert("비밀번호가 성공적으로 변경되었습니다.");
+    router.replace("/login");
+    // } catch (err) {
+    //   if (err instanceof Error) {
+    //     alert(err.message);
+    //   } else {
+    //     alert("알 수 없는 오류가 발생했습니다.");
+    //   }
+    // } finally {
+    //   setIsLoading(false);
+    // }
+  };
+
+  return {
+    formState,
+    errors,
+    isLoading,
+    handleFormChange,
+    handleResetPassword,
+  };
+};
+
+export default usePasswordResetForm;


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
비밀번호 재설정 이메일 전송화면과 비밀번호 재설정 UI를 추가했습니다.

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- web IDE때 쓰던 비밀번호 재설정 이메일 전송화면 비밀번호 재설정 UI추가
- legacy-peer-deps 설정을 위한 .npmrc 추가


## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
|비밀밀번호 재설정 이메일 전송|비밀번호 재설정|
|--|--|
|<img width="597" alt="image" src="https://github.com/user-attachments/assets/c8e8f8e6-7dfd-44b8-ba8f-feb7d8145037" />|<img width="603" alt="image" src="https://github.com/user-attachments/assets/afa799e7-3f89-4b3e-a572-74467979b639" />|



## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [ ] 변수명, 함수명 명확하게 작성
- [ ] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->



## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
