### PR TITLE
글 작성 페이지와 에디터의 레이아웃과 기본 설정, indexedDB 기반의 임시 저장 기능 구현

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/src/app/editor/EditorPageClient.tsx
+++ b/src/app/editor/EditorPageClient.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const PostEditor = dynamic(() => import("@/components/editor/PostEditor"), {
+  ssr: false,
+});
+
+export default function EditorWrapper() {
+  return <PostEditor />;
+}

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -2,8 +2,7 @@ import PostEditor from "@/components/editor/PostEditor";
 
 export default function WritePage() {
   return (
-    <main className="min-h-screen bg-gray-50 p-6">
-      <h1 className="text-2xl font-bold mb-6">글쓰기</h1>
+    <main className="min-h-screen p-6">
       <PostEditor />
     </main>
   );

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,9 +1,9 @@
-import PostEditor from "@/components/editor/PostEditor";
+import EditorWrapper from "./EditorPageClient";
 
 export default function WritePage() {
   return (
     <main className="min-h-screen p-6">
-      <PostEditor />
+      <EditorWrapper />
     </main>
   );
 }

--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -1,0 +1,10 @@
+import PostEditor from "@/components/editor/PostEditor";
+
+export default function WritePage() {
+  return (
+    <main className="min-h-screen bg-gray-50 p-6">
+      <h1 className="text-2xl font-bold mb-6">글쓰기</h1>
+      <PostEditor />
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,3 +32,17 @@ body {
 .overflow-y-auto::-webkit-scrollbar-track {
   background: transparent;
 }
+
+/* Toast 에디터 */
+.toastui-editor-main .toastui-editor-md-vertical-style .toastui-editor {
+  width: 100% !important;
+}
+
+.toastui-editor-md-splitter {
+  display: none !important;
+}
+
+.toastui-editor-md-preview {
+  display: none;
+  width: 0 !important;
+}

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -16,6 +16,7 @@ export default function PostEditor() {
         <select
           value={category ?? ""}
           onChange={(e) => setCategory(e.target.value)}
+          className="h-10 p-1 bg-violet300 rounded-lg"
         >
           <option value="">게시판 선택</option>
           <option value="자취일상">자취일상</option>
@@ -37,7 +38,7 @@ export default function PostEditor() {
         initialValue="테스트"
         previewStyle="vertical"
         height="400px"
-        initialEditType="markdown"
+        initialEditType="wysiwyg"
         useCommandShortcut={true}
         toolbarItems={[
           ["heading", "bold", "italic", "strike"],

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -12,7 +12,7 @@ export default function PostEditor() {
       <Editor
         ref={editorRef}
         initialValue="테스트"
-        previewStyle="vertical"
+        previewStyle="tab"
         height="400px"
         initialEditType="markdown"
         useCommandShortcut={true}
@@ -20,7 +20,7 @@ export default function PostEditor() {
           ['heading', 'bold', 'italic', 'strike'],
           ['hr', 'quote'],
           ['ul', 'ol', 'task'],
-          ['link'],
+          ['link', 'image'],
           ['code', 'codeblock']
         ]}
       />

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -2,13 +2,24 @@
 
 import { Editor } from "@toast-ui/react-editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 
 export default function PostEditor() {
   const editorRef = useRef<Editor>(null);
+  const [title, setTitle] = useState("");
 
   return (
     <div className="w-full max-w-3xl mx-auto p-4 bg-white rounded-xl shadow">
+      {/* 제목 입력창 */}
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="제목을 입력하세요"
+        className="w-full text-2xl font-semibold border-none outline-none placeholder-gray-400 mb-6"
+      />
+
+      {/* 본문 에디터 */}
       <Editor
         ref={editorRef}
         initialValue="테스트"

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -12,7 +12,7 @@ export default function PostEditor() {
       <Editor
         ref={editorRef}
         initialValue="테스트"
-        previewStyle="tab"
+        previewStyle="vertical"
         height="400px"
         initialEditType="markdown"
         useCommandShortcut={true}

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -4,6 +4,8 @@ import { Editor } from "@toast-ui/react-editor";
 import { useRef, useEffect } from "react";
 import { usePostStore } from "@/stores/usePostStore";
 import { saveDraft, loadDraft } from "@/utils/editorStorage";
+import BaseButton from "@/components/common/Button/BaseButton";
+import { SaveIcon } from "lucide-react";
 
 export default function PostEditor() {
   const editorRef = useRef<Editor>(null);
@@ -14,10 +16,10 @@ export default function PostEditor() {
     const interval = setInterval(() => {
       const content = editorRef.current?.getInstance().getMarkdown() ?? "";
       console.log("💾 저장 시도 내용:", { title, category, content });
-      saveDraft({ 
-        title, 
-        category: category ?? "", 
-        content 
+      saveDraft({
+        title,
+        category: category ?? "",
+        content,
       });
       console.log("자동 임시저장됨");
     }, 5000); // 5초마다 자동 저장
@@ -55,7 +57,11 @@ export default function PostEditor() {
 
         {/* 임시 저장 버튼 */}
         <div>
-          <button
+          <BaseButton
+            type="button"
+            leftIcon={<SaveIcon />}
+            size="md"
+            color="skyblue300"
             onClick={() => {
               const instance = editorRef.current?.getInstance();
               if (!instance) {
@@ -66,17 +72,17 @@ export default function PostEditor() {
               const content = instance.getMarkdown();
               console.log("수동 저장 내용:", { title, category, content });
 
-              saveDraft({ 
-                title, 
+              saveDraft({
+                title,
                 category: category ?? "",
-                content 
+                content,
               });
               alert("임시 저장 완료!");
             }}
-            className="h-10 p-1 bg-gray-200 rounded-lg hover:bg-gray-300"
+            className="p-1"
           >
-            💾 임시 저장
-          </button>
+            임시 저장
+          </BaseButton>
         </div>
       </div>
 
@@ -106,12 +112,18 @@ export default function PostEditor() {
         ]}
       />
       <div className="flex gap-2 justify-end">
-        <button className="w-[80px] mt-4 px-4 py-2 bg-violet600 text-white rounded">
+        <BaseButton
+          type="button"
+          className="w-[80px] h-[40px] mt-4 px-4 py-2 bg-violet600 text-white rounded"
+        >
           등록
-        </button>
-        <button className="w-[80px] mt-4 px-4 py-2 bg-gray200 text-white rounded">
+        </BaseButton>
+        <BaseButton
+          type="button"
+          className="w-[80px] h-[40px] mt-4 px-4 py-2 bg-gray200 text-white rounded"
+        >
           취소
-        </button>
+        </BaseButton>
       </div>
     </div>
   );

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Editor } from "@toast-ui/react-editor";
+import "@toast-ui/editor/dist/toastui-editor.css";
+import { useRef } from "react";
+
+export default function PostEditor() {
+  const editorRef = useRef<Editor>(null);
+
+  return (
+    <div className="w-full max-w-3xl mx-auto p-4 bg-white rounded-xl shadow">
+      <Editor
+        ref={editorRef}
+        initialValue="테스트"
+        previewStyle="vertical"
+        height="400px"
+        initialEditType="markdown"
+        useCommandShortcut={true}
+        toolbarItems={[
+          ['heading', 'bold', 'italic', 'strike'],
+          ['hr', 'quote'],
+          ['ul', 'ol', 'task'],
+          ['link'],
+          ['code', 'codeblock']
+        ]}
+      />
+    </div>
+  );
+}

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -17,7 +17,7 @@ export default function PostEditor() {
         value={title}
         onChange={(e) => setTitle(e.target.value)}
         placeholder="제목을 입력하세요"
-        className="w-full text-2xl font-semibold border-none outline-none placeholder-gray-400 mb-6"
+        className="w-full h-[60px] text-2xl font-semibold outline-none placeholder-gray-400 mb-6 px-3 py-2 rounded-md bg-white shadow-[0_1px_4px_rgba(0,0,0,0.1)] focus:shadow-[0_2px_6px_rgba(0,0,0,0.2)] transition"
       />
 
       {/* 본문 에디터 */}

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -2,11 +2,12 @@
 
 import { Editor } from "@toast-ui/react-editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
-import { useRef, useState } from "react";
+import { useRef } from "react";
+import { usePostStore } from "@/stores/usePostStore";
 
 export default function PostEditor() {
   const editorRef = useRef<Editor>(null);
-  const [title, setTitle] = useState("");
+  const { title, setTitle } = usePostStore();
 
   return (
     <div className="w-full max-w-3xl mx-auto p-4 bg-white rounded-xl shadow">

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -7,10 +7,21 @@ import { usePostStore } from "@/stores/usePostStore";
 
 export default function PostEditor() {
   const editorRef = useRef<Editor>(null);
-  const { title, setTitle } = usePostStore();
+  const { title, setTitle, category, setCategory } = usePostStore();
 
   return (
     <div className="w-full max-w-3xl mx-auto p-4 bg-white rounded-xl shadow">
+      {/* 카테고리 선택 (임시) */}
+      <div className="my-4">
+        <select
+          value={category ?? ""}
+          onChange={(e) => setCategory(e.target.value)}
+        >
+          <option value="">게시판 선택</option>
+          <option value="자취일상">자취일상</option>
+          <option value="같이쓰자">같이쓰자</option>
+        </select>
+      </div>
       {/* 제목 입력창 */}
       <input
         type="text"

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -17,13 +17,21 @@ export default function PostEditor() {
         initialEditType="markdown"
         useCommandShortcut={true}
         toolbarItems={[
-          ['heading', 'bold', 'italic', 'strike'],
-          ['hr', 'quote'],
-          ['ul', 'ol', 'task'],
-          ['link', 'image'],
-          ['code', 'codeblock']
+          ["heading", "bold", "italic", "strike"],
+          ["hr", "quote"],
+          ["ul", "ol", "task"],
+          ["link", "image"],
+          ["code", "codeblock"],
         ]}
       />
+      <div className="flex gap-2 justify-end">
+        <button className="w-[80px] mt-4 px-4 py-2 bg-violet600 text-white rounded">
+          등록
+        </button>
+        <button className="w-[80px] mt-4 px-4 py-2 bg-gray200 text-white rounded">
+          취소
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -2,27 +2,70 @@
 
 import { Editor } from "@toast-ui/react-editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
-import { useRef } from "react";
+import { useRef, useEffect } from "react";
 import { usePostStore } from "@/stores/usePostStore";
+import { saveDraft, loadDraft } from "@/utils/editorStorage";
 
 export default function PostEditor() {
   const editorRef = useRef<Editor>(null);
   const { title, setTitle, category, setCategory } = usePostStore();
 
+  // 자동 임시 저장
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const content = editorRef.current?.getInstance().getMarkdown() ?? "";
+      console.log("💾 저장 시도 내용:", { title, category, content });
+      saveDraft({ title, category, content });
+      console.log("자동 임시저장됨");
+    }, 5000); // 5초마다 자동 저장
+
+    return () => clearInterval(interval);
+  }, [title, category]);
+
+  // 임시 저장 자동 불러오기
+  useEffect(() => {
+    loadDraft().then((draft) => {
+      if (draft) {
+        console.log("🟢 불러온 초안", draft);
+        setTitle(draft.title);
+        setCategory(draft.category);
+        editorRef.current?.getInstance().setMarkdown(draft.content);
+      }
+    });
+  }, []);
+
   return (
     <div className="w-full max-w-3xl mx-auto p-4 bg-white rounded-xl shadow">
-      {/* 카테고리 선택 (임시) */}
-      <div className="my-4">
-        <select
-          value={category ?? ""}
-          onChange={(e) => setCategory(e.target.value)}
-          className="h-10 p-1 bg-violet300 rounded-lg"
-        >
-          <option value="">게시판 선택</option>
-          <option value="자취일상">자취일상</option>
-          <option value="같이쓰자">같이쓰자</option>
-        </select>
+      <div className="flex justify-between items-center">
+        {/* 카테고리 선택 (임시) */}
+        <div className="my-4">
+          <select
+            value={category ?? ""}
+            onChange={(e) => setCategory(e.target.value)}
+            className="h-10 p-1 bg-violet300 rounded-lg"
+          >
+            <option value="">게시판 선택</option>
+            <option value="자취일상">자취일상</option>
+            <option value="같이쓰자">같이쓰자</option>
+          </select>
+        </div>
+
+        {/* 임시 저장 버튼 */}
+        <div>
+          <button
+            onClick={() => {
+              const content =
+                editorRef.current?.getInstance().getMarkdown() ?? "";
+              saveDraft({ title, category, content });
+              alert("임시 저장 완료!");
+            }}
+            className="h-10 p-1 bg-gray-200 rounded-lg hover:bg-gray-300"
+          >
+            💾 임시 저장
+          </button>
+        </div>
       </div>
+
       {/* 제목 입력창 */}
       <input
         type="text"
@@ -35,7 +78,7 @@ export default function PostEditor() {
       {/* 본문 에디터 */}
       <Editor
         ref={editorRef}
-        initialValue="테스트"
+        initialValue=""
         previewStyle="vertical"
         height="400px"
         initialEditType="wysiwyg"

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -15,7 +15,11 @@ export default function PostEditor() {
     const interval = setInterval(() => {
       const content = editorRef.current?.getInstance().getMarkdown() ?? "";
       console.log("💾 저장 시도 내용:", { title, category, content });
-      saveDraft({ title, category, content });
+      saveDraft({ 
+        title, 
+        category: category ?? "", 
+        content 
+      });
       console.log("자동 임시저장됨");
     }, 5000); // 5초마다 자동 저장
 
@@ -32,7 +36,7 @@ export default function PostEditor() {
         editorRef.current?.getInstance().setMarkdown(draft.content);
       }
     });
-  }, []);
+  }, [setTitle, setCategory]);
 
   return (
     <div className="w-full max-w-3xl mx-auto p-4 bg-white rounded-xl shadow">
@@ -54,9 +58,20 @@ export default function PostEditor() {
         <div>
           <button
             onClick={() => {
-              const content =
-                editorRef.current?.getInstance().getMarkdown() ?? "";
-              saveDraft({ title, category, content });
+              const instance = editorRef.current?.getInstance();
+              if (!instance) {
+                console.warn("에디터 인스턴스를 찾을 수 없음");
+                return;
+              }
+
+              const content = instance.getMarkdown();
+              console.log("수동 저장 내용:", { title, category, content });
+
+              saveDraft({ 
+                title, 
+                category: category ?? "",
+                content 
+              });
               alert("임시 저장 완료!");
             }}
             className="h-10 p-1 bg-gray-200 rounded-lg hover:bg-gray-300"

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Editor } from "@toast-ui/react-editor";
-import "@toast-ui/editor/dist/toastui-editor.css";
 import { useRef, useEffect } from "react";
 import { usePostStore } from "@/stores/usePostStore";
 import { saveDraft, loadDraft } from "@/utils/editorStorage";

--- a/src/stores/usePostStore.ts
+++ b/src/stores/usePostStore.ts
@@ -1,0 +1,39 @@
+import { create } from "zustand";
+
+type PostState = {
+    title: string;
+    content: string;
+    category: string | null;
+    imageUrlList: string[];
+    thumbnailUrl: string | null;
+  
+    setTitle: (title: string) => void;
+    setContent: (content: string) => void;
+    setCategory: (category: string) => void;
+    setImageUrlList: (list: string[]) => void;
+    setThumbnailUrl: (url: string | null) => void;
+    resetPost: () => void;
+  };
+
+  export const usePostStore = create<PostState>((set) => ({
+    title: "",
+    content: "",
+    category: null,
+    imageUrlList: [],
+    thumbnailUrl: null,
+  
+    setTitle: (title) => set({ title }),
+    setContent: (content) => set({ content }),
+    setCategory: (category) => set({ category }),
+    setImageUrlList: (list) => set({ imageUrlList: list }),
+    setThumbnailUrl: (url) => set({ thumbnailUrl: url }),
+  
+    resetPost: () =>
+      set({
+        title: "",
+        content: "",
+        category: null,
+        imageUrlList: [],
+        thumbnailUrl: null,
+      }),
+  }));

--- a/src/stores/usePostStore.ts
+++ b/src/stores/usePostStore.ts
@@ -1,39 +1,39 @@
 import { create } from "zustand";
 
 type PostState = {
-    title: string;
-    content: string;
-    category: string | null;
-    imageUrlList: string[];
-    thumbnailUrl: string | null;
-  
-    setTitle: (title: string) => void;
-    setContent: (content: string) => void;
-    setCategory: (category: string | null) => void;
-    setImageUrlList: (list: string[]) => void;
-    setThumbnailUrl: (url: string | null) => void;
-    resetPost: () => void;
-  };
+  title: string;
+  content: string;
+  category: string | null;
+  imageUrlList: string[];
+  thumbnailUrl: string | null;
 
-  export const usePostStore = create<PostState>((set) => ({
-    title: "",
-    content: "",
-    category: null,
-    imageUrlList: [],
-    thumbnailUrl: null,
-  
-    setTitle: (title) => set({ title }),
-    setContent: (content) => set({ content }),
-    setCategory: (category) => set({ category }),
-    setImageUrlList: (list) => set({ imageUrlList: list }),
-    setThumbnailUrl: (url) => set({ thumbnailUrl: url }),
-  
-    resetPost: () =>
-      set({
-        title: "",
-        content: "",
-        category: null,
-        imageUrlList: [],
-        thumbnailUrl: null,
-      }),
-  }));
+  setTitle: (title: string) => void;
+  setContent: (content: string) => void;
+  setCategory: (category: string | null) => void;
+  setImageUrlList: (list: string[]) => void;
+  setThumbnailUrl: (url: string | null) => void;
+  resetPost: () => void;
+};
+
+export const usePostStore = create<PostState>((set) => ({
+  title: "",
+  content: "",
+  category: null,
+  imageUrlList: [],
+  thumbnailUrl: null,
+
+  setTitle: (title) => set({ title }),
+  setContent: (content) => set({ content }),
+  setCategory: (category) => set({ category }),
+  setImageUrlList: (list) => set({ imageUrlList: list }),
+  setThumbnailUrl: (url) => set({ thumbnailUrl: url }),
+
+  resetPost: () =>
+    set({
+      title: "",
+      content: "",
+      category: null,
+      imageUrlList: [],
+      thumbnailUrl: null,
+    }),
+}));

--- a/src/stores/usePostStore.ts
+++ b/src/stores/usePostStore.ts
@@ -9,7 +9,7 @@ type PostState = {
   
     setTitle: (title: string) => void;
     setContent: (content: string) => void;
-    setCategory: (category: string) => void;
+    setCategory: (category: string | null) => void;
     setImageUrlList: (list: string[]) => void;
     setThumbnailUrl: (url: string | null) => void;
     resetPost: () => void;

--- a/src/utils/editorStorage.ts
+++ b/src/utils/editorStorage.ts
@@ -1,0 +1,40 @@
+const DB_NAME = "community-post-db";
+const STORE_KEY = "post-draft";
+
+export async function saveDraft(draft: {
+  title: string;
+  category: string | null;
+  content: string;
+}) {
+  const db = await openDB();
+  const tx = db.transaction("drafts", "readwrite");
+  tx.objectStore("drafts").put({ id: STORE_KEY, ...draft });
+}
+
+export async function loadDraft(): Promise<{
+  title: string;
+  category: string | null;
+  content: string;
+} | null> {
+  const db = await openDB();
+  const tx = db.transaction("drafts", "readonly");
+  return new Promise((resolve) => {
+    const req = tx.objectStore("drafts").get(STORE_KEY);
+    req.onsuccess = () => resolve(req.result ?? null);
+    req.onerror = () => resolve(null);
+  });
+}
+
+async function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains("drafts")) {
+        db.createObjectStore("drafts", { keyPath: "id" });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}


### PR DESCRIPTION
## 📌 작업 개요
글 작성 페이지와 에디터의 레이아웃과 기본 설정, indexedDB 기반의 임시 저장 기능 구현


## ✨ 주요 변경 사항
- 글 작성 페이지를 생성하고 본문 작성을 위한 Toast 에디터를 추가하였습니다
- 에디터에서 사용할 기능과 초기 설정을 진행했고 일부 UI를 수정했습니다
- 글 제목 부분과 카테고리 선택, 각종 버튼 등을 페이지에 추가했습니다
- zustand 와 indexedDB를 통해 글 카테고리와 글 제목, 본문이 전부 반영되는 임시 저장을 구현했습니다
- 전체적으로 반응형으로 작동되게 배치를 진행해봤습니다

현재 임시 저장은 5초마다 1번씩 되거나 임시 저장 버튼을 통해 가능하고
글 작성 페이지 진입 시 자동으로 불러오도록 설정되있습니다 !

## 🖼️ 스크린샷 (선택)
<img width="826" alt="image" src="https://github.com/user-attachments/assets/4bc9938d-9ed0-4e38-a058-04c3b86032cf" />


## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리


## 📂 테스트 방법
임시 저장 기능 테스트 완료
npm run build 통과



## 💬 기타 참고 사항

확인 때문에 console.log 가 많이 들어간 상태인데, 
글 작성 api 연결 및 테스트 진행 후에 전부 지우도록 하겠습니다 !
일단 배치와 약간에 디자인만 한거라 뭔가 부족한 느낌이 엄청나네요
디자인을 조금 더 고민을 해봐야 할 것 같습니다

일단 생각에는
임시 저장 버튼을 누르면 토스트 팝업으로 성공 실패 메세지를 주면 좋을 것 같고
카테고리 선택 리스트도 IDE 때 처럼 option 이 아니라 커스텀을 해야할 것 같습니다