### PR TITLE
이메일 회원가입 및 로그인 API연결

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+NEXT_PUBLIC_API_BASE_URL=baseurl
 KAKAO_CLIENT_ID=kakaoClientId
 KAKAO_CLIENT_SECRET=kakaoClientSecret
 NEXTAUTH_URL=http://localhost:3000

--- a/src/app/api/auth/signin/route.ts
+++ b/src/app/api/auth/signin/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from "next/server";
+import { createErrorResponse, createSuccessResponse } from "@/lib/response";
+import { saveAuthCookies } from "@/lib/auth/cookie";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+export async function POST(req: NextRequest) {
+  try {
+    const credentials = await req.json();
+
+    const res = await fetch(`${API_BASE_URL}/auth/signin`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(credentials),
+    });
+
+    const data = await res.json();
+    if (!res.ok) {
+      return createErrorResponse(data.message ?? "로그인 실패", res.status);
+    }
+
+    return createSuccessResponse(null, "로그인 성공");
+  } catch (err) {
+    return createErrorResponse(`서버 오류: ${err}`, 500);
+  }
+}

--- a/src/app/api/auth/signin/route.ts
+++ b/src/app/api/auth/signin/route.ts
@@ -21,6 +21,10 @@ export async function POST(req: NextRequest) {
       return createErrorResponse(data.message ?? "로그인 실패", res.status);
     }
 
+    const { accessToken, refreshToken } = data.data;
+
+    await saveAuthCookies({ accessToken, refreshToken });
+
     return createSuccessResponse(null, "로그인 성공");
   } catch (err) {
     return createErrorResponse(`서버 오류: ${err}`, 500);

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from "next/server";
+import { createSuccessResponse, createErrorResponse } from "@/lib/response";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/signup`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      },
+    );
+
+    const data = await res.json();
+    if (!res.ok) {
+      return createErrorResponse(data.message ?? "회원가입 실패", res.status);
+    }
+
+    return createSuccessResponse(
+      {
+        id: data.data.id,
+        email: data.data.email,
+        nickname: data.data.nickname,
+      },
+      "회원가입 성공",
+    );
+  } catch (err) {
+    return createErrorResponse(`서버 오류: ${err}`, 500);
+  }
+}

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -1,20 +1,19 @@
 import { NextRequest } from "next/server";
 import { createSuccessResponse, createErrorResponse } from "@/lib/response";
 
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
 
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/signup`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
+    const res = await fetch(`${API_BASE_URL}/auth/signup`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
       },
-    );
+      body: JSON.stringify(body),
+    });
 
     const data = await res.json();
     if (!res.ok) {

--- a/src/components/auth/LoginForm/useLoginForm.ts
+++ b/src/components/auth/LoginForm/useLoginForm.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { userLogin } from "@/lib/api/auth";
 import { validateEmail, validatePassword } from "@/utils/validate";
 import { Session } from "next-auth";
 import { signIn, useSession } from "next-auth/react";
@@ -69,19 +70,12 @@ const useLoginForm = () => {
 
     handleLoadingChange("email", true);
     try {
-      // const response = await userLogin({
-      //   email: formState.email,
-      //   password: formState.password,
-      // });
-      // saveAuthCookie(
-      //   response.accessToken,
-      //   response.refreshToken,
-      //   response.userId,
-      // );
-      // useAuthStore.getState().setAuth(response.accessToken, "local", {
-      //   nickname: response.nickname,
-      //   userId: response.userId,
-      // });
+      await userLogin({
+        email: formState.email,
+        password: formState.password,
+      });
+
+      router.replace("/");
     } catch (err) {
       if (err instanceof Error) {
         alert(err.message);

--- a/src/components/auth/Signup/useSignupForm.ts
+++ b/src/components/auth/Signup/useSignupForm.ts
@@ -1,3 +1,4 @@
+import { userSignup } from "@/lib/api/auth";
 import { AgreementsState, AgreementsType } from "@/types/agreement";
 import {
   validateEmail,
@@ -96,14 +97,13 @@ const useSignupForm = () => {
 
     setIsLoading(true);
     try {
-      // await userSignup({
-      // 	email: formState.email,
-      // 	password: formState.password,
-      // 	nickname: formState.nickname,
-      // });
+      const email = await userSignup({
+        email: formState.email,
+        password: formState.password,
+        nickname: formState.nickname,
+      });
 
-      // TODO: 회원가입 완료 후 ux 수정 필요
-      router.replace("/email-validation?email=" + formState.email);
+      router.replace("/email-validation?email=" + email);
     } catch (err) {
       if (err instanceof Error) {
         alert(err.message);

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -18,6 +18,7 @@ const Layout = ({ children }: LayoutProps) => {
     "/signup",
     "/password-forget",
     "/password-reset",
+    "/email-validation",
   ];
 
   const shouldHideHeader = hideHeaderRoutes.includes(pathname);

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,0 +1,21 @@
+import { SignupCredentials } from "@/types/auth";
+
+export const userSignup = async (
+  credentials: SignupCredentials,
+): Promise<string> => {
+  const res = await fetch("/api/auth/signup", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(credentials),
+  });
+
+  const body = await res.json();
+
+  if (!res.ok) {
+    throw new Error(body.message ?? "회원가입 실패");
+  }
+
+  return body.data.email;
+};

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,4 +1,4 @@
-import { SignupCredentials } from "@/types/auth";
+import { AuthCredentials, SignupCredentials } from "@/types/auth";
 
 export const userSignup = async (
   credentials: SignupCredentials,
@@ -18,4 +18,21 @@ export const userSignup = async (
   }
 
   return body.data.email;
+};
+
+// 로그인 성공 시 별도 반환 없음 (쿠키는 서버에서 저장됨)
+export const userLogin = async (
+  credentials: AuthCredentials,
+): Promise<void> => {
+  const res = await fetch("/api/auth/signin", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(credentials),
+  });
+
+  const body = await res.json();
+
+  if (!res.ok) {
+    throw new Error(body.message ?? "로그인 실패");
+  }
 };

--- a/src/lib/auth/cookie.ts
+++ b/src/lib/auth/cookie.ts
@@ -1,0 +1,44 @@
+import { cookies } from "next/headers";
+
+const ACCESS_TOKEN = "access_token";
+const REFRESH_TOKEN = "refresh_token";
+
+// SSR에서 쿠키 저장
+export async function saveAuthCookies({
+  accessToken,
+  refreshToken,
+}: {
+  accessToken: string;
+  refreshToken: string;
+}) {
+  const cookieStore = await cookies();
+  const isProd = process.env.NODE_ENV === "production";
+
+  // 공통 설정
+  const baseOptions = {
+    path: "/",
+    secure: isProd,
+  };
+
+  // accessToken: CSR에서도 사용 가능
+  cookieStore.set(ACCESS_TOKEN, accessToken, {
+    ...baseOptions,
+    maxAge: 60 * 60 * 24, // 1일
+    sameSite: "lax",
+  });
+
+  // refreshToken: 서버에서만 사용
+  cookieStore.set(REFRESH_TOKEN, refreshToken, {
+    ...baseOptions,
+    maxAge: 60 * 60 * 24 * 7, // 7일
+    sameSite: "strict",
+    httpOnly: true,
+  });
+}
+
+// SSR에서 쿠키 삭제
+export async function removeAuthCookies() {
+  const cookieStore = await cookies();
+  cookieStore.delete(ACCESS_TOKEN);
+  cookieStore.delete(REFRESH_TOKEN);
+}

--- a/src/lib/response.ts
+++ b/src/lib/response.ts
@@ -1,0 +1,21 @@
+export function createSuccessResponse<T>(
+  data: T,
+  message = "요청 성공",
+  status = 200,
+) {
+  return new Response(JSON.stringify({ message, data }), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+export function createErrorResponse(message: string, status = 400) {
+  return new Response(JSON.stringify({ status, message }), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -3,3 +3,8 @@ interface SignupCredentials {
   password: string;
   nickname: string;
 }
+
+interface AuthCredentials {
+  email: string;
+  password: string;
+}

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -1,0 +1,5 @@
+interface SignupCredentials {
+  email: string;
+  password: string;
+  nickname: string;
+}


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
이메일 회원가입 및 로그인 API를 연결했습니다.

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- base url을 추가했습니다.
- api응답 핸들링을 위한 공통 response 모델을 추가했습니다.
- Route Handler를 통해 회원가입, 로그인 api를 호출하도록 했습니다.
  - Route Handler를 쓰면 프론트엔드 코드에서 API URL 노출이 방지되고 서버에서 쿠키설정, 토큰 자동 주입등이 가능하다고합니다.
  - signin(로그인)을 할 경우 accessToken, refreshToken을 쿠키에 저장하고 홈화면으로 이동한 후 user/my를 호출해서 사용자 정보를 전역으로 저장하려고 합니다. 이전에는 signup에서 데이터를 받아와서 저장했는데 현업에서는 홈화면 이동해서 다시 정보를 받아온다고하네요.


## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
|회원가입 및 로그인 완료 후 users/my 호출 결과|
|--|
|<img width="1420" alt="image" src="https://github.com/user-attachments/assets/a504277d-dbef-4837-bcb9-a5daa5055703" />|

## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->



## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
에러 핸들링은 현재는 alert로 나옵니다..
얼른 토스트 적용하도록 할게요..!