### PR TITLE
Toast UI 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import "@toast-ui/editor/dist/toastui-editor.css";
 import Providers from "@/providers/Providers";
 import Layout from "@/components/layout/Layout";
+import { ToastMessageContainer } from "@/components/common/ToastMessage";
 
 export const metadata: Metadata = {
   title: "ZARO",
@@ -25,6 +26,7 @@ export default function RootLayout({
       <body>
         <Providers>
           <Layout>{children}</Layout>
+          <ToastMessageContainer />
         </Providers>
       </body>
     </html>

--- a/src/components/auth/LoginForm/useLoginForm.ts
+++ b/src/components/auth/LoginForm/useLoginForm.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { userLogin } from "@/lib/api/auth";
+import { useToastMessageContext } from "@/providers/ToastMessageProvider";
 import { validateEmail, validatePassword } from "@/utils/validate";
 import { Session } from "next-auth";
 import { signIn, useSession } from "next-auth/react";
@@ -33,6 +34,7 @@ const useLoginForm = () => {
     email: false,
     kakao: false,
   });
+  const { showToastMessage } = useToastMessageContext();
 
   const validateForm = useCallback(() => {
     const newErrors: LoginFormErrors = {};
@@ -77,11 +79,8 @@ const useLoginForm = () => {
 
       router.replace("/");
     } catch (err) {
-      if (err instanceof Error) {
-        alert(err.message);
-      } else {
-        alert("알 수 없는 오류가 발생했습니다.");
-      }
+      const errorMessage = err instanceof Error ? err.message : "로그인 실패";
+      showToastMessage({ type: "error", message: errorMessage });
     } finally {
       handleLoadingChange("email", false);
     }

--- a/src/components/auth/Signup/useSignupForm.ts
+++ b/src/components/auth/Signup/useSignupForm.ts
@@ -1,4 +1,5 @@
 import { userSignup } from "@/lib/api/auth";
+import { useToastMessageContext } from "@/providers/ToastMessageProvider";
 import { AgreementsState, AgreementsType } from "@/types/agreement";
 import {
   validateEmail,
@@ -32,6 +33,8 @@ const useSignupForm = () => {
   });
   const [errors, setErrors] = useState<SignupFormErrors>({});
   const [isLoading, setIsLoading] = useState(false);
+
+  const { showToastMessage } = useToastMessageContext();
 
   const validateForm = useCallback(() => {
     const newErrors: SignupFormErrors = {};
@@ -91,7 +94,7 @@ const useSignupForm = () => {
     if (!validateForm()) return;
 
     if (!agreements.terms || !agreements.privacy) {
-      alert("필수 약관에 동의해주세요");
+      showToastMessage({ type: "error", message: "필수 약관에 동의해주세요" });
       return;
     }
 
@@ -105,11 +108,8 @@ const useSignupForm = () => {
 
       router.replace("/email-validation?email=" + email);
     } catch (err) {
-      if (err instanceof Error) {
-        alert(err.message);
-      } else {
-        alert("알 수 없는 오류가 발생했습니다.");
-      }
+      const errorMessage = err instanceof Error ? err.message : "회원가입 실패";
+      showToastMessage({ type: "error", message: errorMessage });
     } finally {
       setIsLoading(false);
     }

--- a/src/components/common/Input/PasswordInput.tsx
+++ b/src/components/common/Input/PasswordInput.tsx
@@ -19,6 +19,7 @@ const PasswordInput = memo(
 
     const VisibilityToggle = (
       <IconButton
+        type="button"
         icon={isVisible ? <EyeCloseIcon /> : <EyeIcon />}
         label={isVisible ? "비밀번호 숨기기" : "비밀번호 표시"}
         isTransparent

--- a/src/components/common/ToastMessage/ToastMessageContainer.tsx
+++ b/src/components/common/ToastMessage/ToastMessageContainer.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useToastMessageContext } from "@/providers/ToastMessageProvider";
+import ToastMessageItem from "./ToastMessageItem";
+
+const ToastMessageContainer = () => {
+  const { toastMessages } = useToastMessageContext();
+
+  return (
+    <div
+      className="fixed bottom-32 left-4 sm:left-6 z-50 flex flex-col gap-4 w-full max-w-md px-4 pointer-events-auto"
+      aria-live="polite"
+    >
+      {toastMessages.map((toast) => (
+        <ToastMessageItem key={toast.id} {...toast} />
+      ))}
+    </div>
+  );
+};
+
+export default ToastMessageContainer;

--- a/src/components/common/ToastMessage/ToastMessageItem.tsx
+++ b/src/components/common/ToastMessage/ToastMessageItem.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import clsx from "clsx";
+
+import IconButton from "@/components/common/Button/IconButton";
+import { type ToastMessageProps } from "@/types/toastMessage";
+import { useToastMessageContext } from "@/providers/ToastMessageProvider";
+import { CloseIcon } from "../Icons";
+
+const ToastMessageItem = ({ id, message, type }: ToastMessageProps) => {
+  const { removeToastMessage } = useToastMessageContext();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setMounted(true), 10);
+    return () => clearTimeout(timeout);
+  }, [id]);
+
+  const typeClasses = {
+    error: "bg-red200 text-gray600",
+    success: "bg-green200 text-gray600",
+    info: "bg-skyblue100 text-gray600",
+  };
+
+  return (
+    <div
+      role="status"
+      className={clsx(
+        "flex items-center justify-between w-full p-4 shadow-lg rounded-xl animate-slideIn",
+        typeClasses[type],
+        mounted ? "opacity-100" : "opacity-0",
+      )}
+    >
+      <span className="text-body font-medium pr-4">{message}</span>
+      <IconButton
+        icon={<CloseIcon />}
+        label="알림 닫기"
+        onClick={() => removeToastMessage(id)}
+        isTransparent
+        className="hover:bg-white/20"
+        aria-label="알림 닫기"
+      />
+    </div>
+  );
+};
+
+export default ToastMessageItem;

--- a/src/components/common/ToastMessage/index.ts
+++ b/src/components/common/ToastMessage/index.ts
@@ -1,0 +1,6 @@
+export { default as ToastMessageContainer } from "./ToastMessageContainer";
+export { default as ToastMessageItem } from "./ToastMessageItem";
+export {
+  ToastMessageProvider,
+  useToastMessageContext,
+} from "@/providers/ToastMessageProvider";

--- a/src/providers/Providers.tsx
+++ b/src/providers/Providers.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { SessionProvider } from "next-auth/react";
+import { ToastMessageProvider } from "./ToastMessageProvider";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <ToastMessageProvider>{children}</ToastMessageProvider>
+    </SessionProvider>
+  );
 }

--- a/src/providers/ToastMessageProvider.tsx
+++ b/src/providers/ToastMessageProvider.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  type ReactNode,
+} from "react";
+import {
+  type ToastMessageProps,
+  type ToastMessageContextType,
+  type ToastMessageType,
+} from "@/types/toastMessage";
+
+const ToastMessageContext = createContext<ToastMessageContextType | null>(null);
+
+export function ToastMessageProvider({ children }: { children: ReactNode }) {
+  const [toastMessages, setToastMessages] = useState<ToastMessageProps[]>([]);
+  const timeoutIds = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+
+  useEffect(() => {
+    const timeouts = timeoutIds.current;
+
+    return () => {
+      timeouts.forEach(clearTimeout);
+      timeouts.clear();
+    };
+  }, []);
+
+  const removeToastMessage = useCallback((id: string) => {
+    console.log("🧹 removeToastMessage called:", id);
+    setToastMessages((prev) => {
+      return prev.filter((msg) => msg.id !== id);
+    });
+  }, []);
+
+  const showToastMessage = useCallback(
+    ({ message, type }: { message: string; type: ToastMessageType }) => {
+      const id = crypto.randomUUID();
+
+      setToastMessages((prev) => {
+        const isDuplicate = prev.some((msg) => msg.message === message);
+        if (isDuplicate) return prev;
+
+        const timeoutId = setTimeout(() => {
+          setToastMessages((p) => p.filter((m) => m.id !== id));
+          timeoutIds.current.delete(timeoutId);
+        }, 3000);
+
+        timeoutIds.current.add(timeoutId);
+        return [...prev, { id, message, type }];
+      });
+    },
+    [],
+  );
+
+  return (
+    <ToastMessageContext.Provider
+      value={{ toastMessages, showToastMessage, removeToastMessage }}
+    >
+      {children}
+    </ToastMessageContext.Provider>
+  );
+}
+
+export const useToastMessageContext = () => {
+  const context = useContext(ToastMessageContext);
+  if (!context)
+    throw new Error(
+      "useToastMessageContext must be used within ToastMessageProvider",
+    );
+  return context;
+};

--- a/src/types/toastMessage.d.ts
+++ b/src/types/toastMessage.d.ts
@@ -1,0 +1,16 @@
+export type ToastMessageType = "error" | "success" | "info";
+
+export interface ToastMessageProps {
+  id: string;
+  message: string;
+  type: ToastMessageType;
+}
+
+export interface ToastMessageContextType {
+  toastMessages: ToastMessageProps[];
+  showToastMessage: (params: {
+    message: string;
+    type: ToastMessageType;
+  }) => void;
+  removeToastMessage: (id: string) => void;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,6 +28,20 @@ const config = {
         violetGlow: "0 0 4px #744CEB, 0 0 10px #744CEB",
         violetIconGlow: "0 0 2px #744CEB, 0 0 4px #744CEB",
       },
+      keyframes: {
+        slideIn: {
+          "0%": { transform: "translateY(-100%)", opacity: "0" },
+          "100%": { transform: "translateY(0)", opacity: "1" },
+        },
+        modalSlideIn: {
+          "0%": { transform: "translateY(-20px)", opacity: "0" },
+          "100%": { transform: "translateY(0)", opacity: "1" },
+        },
+      },
+      animation: {
+        slideIn: "slideIn 0.3s ease-out forwards",
+        modalSlideIn: "modalSlideIn 0.3s ease-out forwards",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
alert대신 사용할 toast를 추가했습니다.

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- toast provider와 container, toast item을 추가했습니다.

### 사용 방법
alert쓰던 곳 혹은 에러나 알림 표시하려는 파일
```
const { showToastMessage } = useToastMessageContext(); 
// 표시하려는 위치
showToastMessage({ type: "error", message: errorMessage });
```
써주시면 됩니다.
useLoginForm.tsx 참고해주셔도 됩니다!
타입은 **error, success, info**가 있습니다.
현재 토스트는 하나만 표시됩니다!


## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->

|error|success|info|
|--|--|--|
|<img width="442" alt="스크린샷 2025-05-19 오후 2 28 10" src="https://github.com/user-attachments/assets/072f0b6b-4053-4665-a876-cda364320d53" />|<img width="449" alt="스크린샷 2025-05-19 오후 2 28 22" src="https://github.com/user-attachments/assets/4b4ece44-51d2-45b6-bab0-9f20e8b96585" />|<img width="459" alt="스크린샷 2025-05-19 오후 2 28 35" src="https://github.com/user-attachments/assets/aa5c52ee-91dd-43f2-b7d9-05265c11d107" />|


## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->



## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
error일때 색상이 너무 약하지 않나 고민입니다.. ㅎㅎ
색상 변경은 빨리 할 수 있으니 qa때 이야기 해봐야겠어요