### PR TITLE
유저 정보 최신화 및 token refresh api현결

### DIFF
--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,37 @@
+import { cookies } from "next/headers";
+import { createErrorResponse, createSuccessResponse } from "@/lib/response";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL!;
+
+export async function POST() {
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get("refresh_token")?.value;
+
+  if (!refreshToken) {
+    return createErrorResponse("refreshToken이 없습니다.", 401);
+  }
+
+  try {
+    const res = await fetch(`${API_BASE_URL}/auth/refresh`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${refreshToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    const body = await res.json();
+
+    if (!res.ok) {
+      return createErrorResponse(body.message ?? "토큰 갱신 실패", res.status);
+    }
+
+    return createSuccessResponse(
+      { accessToken: body.data.accessToken },
+      "accessToken 갱신 성공",
+    );
+  } catch (err) {
+    console.error("[refreshToken] 서버 오류", err);
+    return createErrorResponse("서버 오류", 500);
+  }
+}

--- a/src/app/api/users/my/route.ts
+++ b/src/app/api/users/my/route.ts
@@ -1,0 +1,34 @@
+import { cookies } from "next/headers";
+import { createSuccessResponse, createErrorResponse } from "@/lib/response";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL!;
+
+export async function GET() {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("access_token")?.value;
+
+  if (!accessToken) {
+    return createErrorResponse("accessToken이 없습니다.", 401);
+  }
+
+  try {
+    const res = await fetch(`${API_BASE_URL}/users/my`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!res.ok) {
+      return createErrorResponse("유저 정보 조회 실패", res.status);
+    }
+
+    const body = await res.json();
+
+    return createSuccessResponse(body.data, "유저 정보 조회 성공");
+  } catch (err) {
+    console.log(err);
+    return createErrorResponse("서버 오류", 500);
+  }
+}

--- a/src/components/AuthInitializer.tsx
+++ b/src/components/AuthInitializer.tsx
@@ -1,0 +1,28 @@
+import { fetchWithAuthClient } from "@/lib/fetch/fetchWithAuth.client";
+import { useAuthStore, UserInfo } from "@/stores/useAuthStore";
+import { useCallback, useEffect } from "react";
+
+const AuthInitializer = ({ children }: { children: React.ReactNode }) => {
+  const { setUser, clearUser, setInitialized } = useAuthStore();
+
+  const initializeAuth = useCallback(async () => {
+    try {
+      const user = await fetchWithAuthClient<UserInfo>("/api/users/my");
+      setUser(user);
+      console.log(user); // 추후 제거 예정
+    } catch (err) {
+      console.log(err);
+      clearUser();
+    } finally {
+      setInitialized();
+    }
+  }, [setUser, clearUser, setInitialized]);
+
+  useEffect(() => {
+    initializeAuth();
+  }, [initializeAuth]);
+
+  return <>{children}</>;
+};
+
+export default AuthInitializer;

--- a/src/lib/fetch/fetchWithAuth.client.ts
+++ b/src/lib/fetch/fetchWithAuth.client.ts
@@ -1,0 +1,62 @@
+import { deleteCookie, getCookie, setCookie } from "cookies-next";
+import { APIErrorResponse, APISuccessResponse } from "@/types/api";
+
+let isRefreshing = false;
+
+export const fetchWithAuthClient = async <T>(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  retry = true,
+): Promise<T> => {
+  const accessToken = getCookie("access_token");
+
+  const headers = new Headers(init?.headers);
+  headers.set("Content-Type", "application/json");
+  if (typeof accessToken === "string")
+    headers.set("Authorization", `Bearer ${accessToken}`);
+
+  const res = await fetch(input, { ...init, headers });
+  const body = await res.json();
+
+  if ((res.status === 401 || res.status === 403) && retry) {
+    await refreshToken();
+    return await fetchWithAuthClient<T>(input, init, false);
+  }
+
+  if (!res.ok) {
+    const errorBody = body as APIErrorResponse;
+    throw new Error(errorBody.message ?? "요청 실패");
+  }
+
+  return (body as APISuccessResponse<T>).data;
+};
+
+const refreshToken = async (): Promise<void> => {
+  if (isRefreshing) return;
+  isRefreshing = true;
+
+  try {
+    const res = await fetch("/api/auth/refresh", { method: "POST" });
+    const body = await res.json();
+
+    if (!res.ok) throw new Error(body?.message ?? "세션이 만료되었습니다.");
+
+    const { accessToken } = (
+      body as APISuccessResponse<{ accessToken: string }>
+    ).data;
+
+    setCookie("access_token", accessToken, {
+      path: "/",
+      maxAge: 60 * 60 * 24,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+    });
+  } catch (err) {
+    deleteCookie("access_token");
+    deleteCookie("refresh_token");
+    window.location.href = "/login";
+    throw err;
+  } finally {
+    isRefreshing = false;
+  }
+};

--- a/src/lib/fetch/fetchWithAuth.ts
+++ b/src/lib/fetch/fetchWithAuth.ts
@@ -1,0 +1,86 @@
+import { cookies } from "next/headers";
+import { deleteCookie, getCookie, setCookie } from "cookies-next";
+import { APIErrorResponse, APISuccessResponse } from "@/types/api";
+
+let isRefreshing = false;
+
+export const fetchWithAuth = async <T>(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  retry = true,
+): Promise<T> => {
+  const accessToken = getAccessToken();
+
+  const headers = new Headers(init?.headers);
+  headers.set("Content-Type", "application/json");
+  if (accessToken) headers.set("Authorization", `Bearer ${accessToken}`);
+
+  const res = await fetch(input, {
+    ...init,
+    headers,
+  });
+
+  const body = await res.json();
+
+  if ((res.status === 401 || res.status === 403) && retry) {
+    await refreshToken();
+    return await fetchWithAuth<T>(input, init, false);
+  }
+
+  if (!res.ok) {
+    const errorBody = body as APIErrorResponse;
+    throw new Error(errorBody.message ?? "요청에 실패했습니다.");
+  }
+
+  const successBody = body as APISuccessResponse<T>;
+  return successBody.data;
+};
+
+const getAccessToken = async (): Promise<string | null> => {
+  if (typeof window === "undefined") {
+    // SSR
+    const cookieStore = await cookies();
+    return cookieStore.get("access_token")?.value ?? null;
+  } else {
+    // CSR
+    const raw = getCookie("access_token");
+    return typeof raw === "string" ? raw : null;
+  }
+};
+
+const refreshToken = async (): Promise<void> => {
+  if (isRefreshing) return;
+  isRefreshing = true;
+
+  try {
+    const res = await fetch("/api/auth/refresh", { method: "POST" });
+    const body = await res.json();
+
+    if (!res.ok) {
+      const errorBody = body as APIErrorResponse;
+      throw new Error(errorBody.message || "세션이 만료되었습니다.");
+    }
+
+    const successBody = body as APISuccessResponse<{ accessToken: string }>;
+    const newToken = successBody.data.accessToken;
+
+    if (typeof window !== "undefined") {
+      // CSR 환경에서만 쿠키 설정
+      setCookie("access_token", newToken, {
+        path: "/",
+        maxAge: 60 * 60 * 24,
+        sameSite: "lax",
+        secure: process.env.NODE_ENV === "production",
+      });
+    }
+  } catch (err) {
+    if (typeof window !== "undefined") {
+      deleteCookie("access_token");
+      deleteCookie("refresh_token");
+      window.location.href = "/login";
+    }
+    throw err;
+  } finally {
+    isRefreshing = false;
+  }
+};

--- a/src/providers/Providers.tsx
+++ b/src/providers/Providers.tsx
@@ -2,11 +2,14 @@
 
 import { SessionProvider } from "next-auth/react";
 import { ToastMessageProvider } from "./ToastMessageProvider";
+import AuthInitializer from "@/components/AuthInitializer";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider>
-      <ToastMessageProvider>{children}</ToastMessageProvider>
+      <ToastMessageProvider>
+        <AuthInitializer>{children}</AuthInitializer>
+      </ToastMessageProvider>
     </SessionProvider>
   );
 }

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+
+export type AuthProvider = "LOCAL" | "KAKAO";
+
+export interface UserInfo {
+  userId: number;
+  email: string;
+  nickname: string;
+  profileImageUrl: string;
+  provider: AuthProvider;
+  // TODO: 선택입력 정보는 추후 추가하기
+}
+
+interface AuthState {
+  user: UserInfo | null;
+  isInitialized: boolean;
+  setUser: (user: UserInfo | null) => void;
+  clearUser: () => void;
+  setInitialized: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  isInitialized: false,
+
+  setUser: (user) => set({ user }),
+  clearUser: () => set({ user: null }),
+  setInitialized: () => set({ isInitialized: true }),
+}));

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,11 @@
+export interface APISuccessResponse<T> {
+  message: string;
+  data: T;
+}
+
+export interface APIErrorResponse {
+  status: number;
+  message: string;
+}
+
+export type APIResponse<T> = APISuccessResponse<T> | APIErrorResponse;


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
users/my를 통한 유저 정보 최신화 및 token refresh 적용

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- API 공통 응답 핸들러를 추가했습니다.
- ssr, csr분리된 api 통신 함수 추가했습니다.
  - fetchWithAuthClient -> CSR
  - fetchWithAuth -> SSR

  SSR일때는 route.ts 생성할 필요없이 사용하면 된다네요. 게시물 상세 같은 곳에서 쓰면 될 것 같습니다.
- AuthInitializer을 추가하여 새로고침 시 유저 정보를 최신화하고, 필요시 accessToken이 refreshe되도록 했습니다.


## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
첨부할만한거 찾다가.. 403만난 후 /api/auth/refresh -> /api/users/my 재요청한 결과 로그입니다.
<img width="641" alt="image" src="https://github.com/user-attachments/assets/da2cb6a8-1a5b-41b4-9501-8b4ab560b694" />


## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->
홈에서 새로고침하면 AuthInitializer에서 유저 정보 로그 찍히는 것 확인할 수 있습니다.


## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
SSR fetch 고민하다 늦었습니다.
CSR, SSR 아직 개념이 너무 어렵네요..ㅠㅠ