### PR TITLE
accessToken, refreshToken없을 경우 무한 호출 이슈 수정

### DIFF
--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -8,7 +8,11 @@ export async function POST() {
   const refreshToken = cookieStore.get("refresh_token")?.value;
 
   if (!refreshToken) {
-    return createErrorResponse("refreshToken이 없습니다.", 401);
+    console.warn("[refreshToken] 쿠키에 refresh_token 없음");
+    return createSuccessResponse(
+      { accessToken: null },
+      "refresh_token 없음 - 로그인 유지 불가",
+    );
   }
 
   try {

--- a/src/app/api/users/my/route.ts
+++ b/src/app/api/users/my/route.ts
@@ -8,7 +8,11 @@ export async function GET() {
   const accessToken = cookieStore.get("access_token")?.value;
 
   if (!accessToken) {
-    return createErrorResponse("accessToken이 없습니다.", 401);
+    console.warn("[accessToken] 쿠키에 access_token 없음");
+    return createSuccessResponse(
+      { accessToken: null },
+      "access_token 없음 - 로그인 유지 불가",
+    );
   }
 
   try {

--- a/src/lib/fetch/client.ts
+++ b/src/lib/fetch/client.ts
@@ -72,20 +72,23 @@ const refreshToken = async (): Promise<boolean> => {
   isRefreshing = true;
 
   try {
-    const res = await fetch("/api/auth/refresh", { method: "POST" });
+    const res = await fetch("/api/auth/refresh", {
+      method: "POST",
+      credentials: "include",
+    });
+
     const body = await res.json();
 
-    if (!res.ok) {
+    // accessToken이 null이면 로그인 유지 실패
+    if (!res.ok || !body?.data?.accessToken) {
       throw new APIErrorResponse({
         code: "AUTH_EXPIRED",
-        message: body?.message ?? "세션이 만료되었습니다.",
-        statusCode: res.status,
+        message: "토큰 갱신 실패 또는 refresh_token 없음",
+        statusCode: 401,
       });
     }
 
-    const { accessToken } = (
-      body as APISuccessResponse<{ accessToken: string }>
-    ).data;
+    const accessToken = body.data.accessToken;
 
     setCookie("access_token", accessToken, {
       path: "/",


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
accessToken 없을 때 무한 호출 이슈 수정

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- access_token이 쿠키에 없을 때 users/my가 무한호출 되는 이슈 수정했습니다.
- 기존에는 401오류를 발생시켰는데 그러다보니 계속 다시 호출되는 이슈가 있었습니다. 
오류일 경우 오류코드가 필수로 있으야하기 때문에 성공으로 하는 대신 오류 로그를 남기도록 했습니다.


## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
<img width="487" alt="image" src="https://github.com/user-attachments/assets/b5964421-6624-4815-b749-560f4a25f4a9" />



## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [ ] 변수명, 함수명 명확하게 작성
- [ ] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->



## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
