### PR TITLE
로그인 사용자일 경우 헤더에 프로필 이미지 표시

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "http",
+        hostname: "k.kakaocdn.net",
+        pathname: "/**", // 하위 모든 경로 허용
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "even-final-front",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "5.76.1",
+        "@tanstack/react-query-devtools": "5.76.1",
         "@toast-ui/editor": "3.2.2",
         "@toast-ui/react-editor": "3.2.3",
         "clsx": "^2.1.1",
@@ -1036,6 +1038,59 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.76.0.tgz",
+      "integrity": "sha512-FN375hb8ctzfNAlex5gHI6+WDXTNpe0nbxp/d2YJtnP+IBM6OUm7zcaoCW6T63BawGOYZBbKC0iPvr41TteNVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.76.0.tgz",
+      "integrity": "sha512-1p92nqOBPYVqVDU0Ua5nzHenC6EGZNrLnB2OZphYw8CNA1exuvI97FVgIKON7Uug3uQqvH/QY8suUKpQo8qHNQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.76.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.76.1.tgz",
+      "integrity": "sha512-YxdLZVGN4QkT5YT1HKZQWiIlcgauIXEIsMOTSjvyD5wLYK8YVvKZUPAysMqossFJJfDpJW3pFn7WNZuPOqq+fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.76.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.76.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.76.1.tgz",
+      "integrity": "sha512-LFVWgk/VtXPkerNLfYIeuGHh0Aim/k9PFGA+JxLdRaUiroQ4j4eoEqBrUpQ1Pd/KXoG4AB9vVE/M6PUQ9vwxBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.76.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.76.1",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@toast-ui/editor": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "check": "npm run lint && npm run format"
   },
   "dependencies": {
+    "@tanstack/react-query": "5.76.1",
+    "@tanstack/react-query-devtools": "5.76.1",
     "@toast-ui/editor": "3.2.2",
     "@toast-ui/react-editor": "3.2.3",
     "clsx": "^2.1.1",

--- a/public/icons/defaultProfile.svg
+++ b/public/icons/defaultProfile.svg
@@ -1,0 +1,8 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100" height="100" fill="#999999"/>
+  <circle cx="50" cy="35" r="20" fill="white"/>
+  <path
+    d="M20 85c0-16.57 13.43-30 30-30s30 13.43 30 30H20z"
+    fill="white"
+  />
+</svg>

--- a/src/components/AuthInitializer.tsx
+++ b/src/components/AuthInitializer.tsx
@@ -32,7 +32,7 @@ const AuthInitializer = ({ children }: { children: React.ReactNode }) => {
   });
 
   useEffect(() => {
-    if (!isSuccess && data) {
+    if (isSuccess && data) {
       setUser(data);
       setInitialized();
     }

--- a/src/components/AuthInitializer.tsx
+++ b/src/components/AuthInitializer.tsx
@@ -2,41 +2,45 @@ import { useEffect } from "react";
 import { getSession } from "next-auth/react";
 import { useAuthStore, UserInfo } from "@/stores/useAuthStore";
 import { client } from "@/lib/fetch/client";
+import { useQuery } from "@tanstack/react-query";
+
+const fetchUserKakaoAccessToken = async (): Promise<UserInfo> => {
+  const session = await getSession();
+  const kakaoAccessToken = session?.user?.accessToken;
+
+  if (kakaoAccessToken) {
+    return await client<UserInfo>("/api/auth/signin/social", {
+      method: "POST",
+      body: JSON.stringify({
+        accessToken: kakaoAccessToken,
+      }),
+    });
+  } else {
+    return await client<UserInfo>("/api/users/my");
+  }
+};
 
 const AuthInitializer = ({ children }: { children: React.ReactNode }) => {
   const { setUser, clearUser, setInitialized, isInitialized } = useAuthStore();
 
-  const initializeAuth = async () => {
-    try {
-      const session = await getSession();
-      const kakaoAccessToken = session?.user?.accessToken;
-      let user: UserInfo | null = null;
-
-      if (kakaoAccessToken) {
-        user = await client<UserInfo>("/api/auth/signin/social", {
-          method: "POST",
-          body: JSON.stringify({
-            accessToken: kakaoAccessToken,
-          }),
-        });
-      } else {
-        user = await client<UserInfo>("/api/users/my");
-      }
-
-      setUser(user);
-    } catch (err) {
-      console.error("AuthInitializer Error:", err);
-      clearUser();
-    } finally {
-      setInitialized();
-    }
-  };
+  const { data, error, isSuccess } = useQuery({
+    queryKey: ["user"],
+    queryFn: fetchUserKakaoAccessToken,
+    enabled: !isInitialized,
+    staleTime: 1000 * 60 * 5,
+    retry: 1,
+  });
 
   useEffect(() => {
-    if (!isInitialized) {
-      initializeAuth();
+    if (!isSuccess && data) {
+      setUser(data);
+      setInitialized();
     }
-  }, [isInitialized]);
+    if (error) {
+      clearUser();
+      setInitialized();
+    }
+  }, [isSuccess, error, data]);
 
   return <>{children}</>;
 };

--- a/src/components/common/Icons/index.tsx
+++ b/src/components/common/Icons/index.tsx
@@ -172,3 +172,16 @@ export const ShoppingBagIcon = ({ className }: IconProps) => {
     />
   );
 };
+
+export const DefaultProfileIcon = ({ className }: IconProps) => {
+  return (
+    <Image
+      src="/icons/defaultProfile.svg"
+      alt="프로필이미지"
+      width={28}
+      height={28}
+      className={className}
+      priority
+    />
+  );
+};

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import IconButton from "@/components/common/Button/IconButton";
 import {
   LogoLineIcon,
@@ -7,14 +9,22 @@ import {
 import Searchbar from "@/components/Searchbar/Searchbar";
 import { ArrowLeftIcon, LogIn, MenuIcon } from "lucide-react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 
 interface HeaderProps {
   onMenuClick: () => void;
-  onLoginClick: () => void;
 }
 
-const Header = ({ onMenuClick, onLoginClick }: HeaderProps) => {
+const Header = ({ onMenuClick }: HeaderProps) => {
+  const pathname = usePathname();
+  const hideHeaderRoutes = [
+    "/login",
+    "/signup",
+    "/password-forget",
+    "/password-reset",
+    "/email-validation",
+  ];
   const [isMobileSearchOpen, setIsMobileSearchOpen] = useState(false);
 
   useEffect(() => {
@@ -31,6 +41,8 @@ const Header = ({ onMenuClick, onLoginClick }: HeaderProps) => {
       window.removeEventListener("resize", handleResize);
     };
   }, []);
+
+  if (hideHeaderRoutes.includes(pathname)) return null;
 
   return (
     <header className="h-[3rem] px-4 sm:px-10 flex items-center justify-between">
@@ -77,12 +89,9 @@ const Header = ({ onMenuClick, onLoginClick }: HeaderProps) => {
             />
           </div>
           <IconButton icon={<NotificationIcon />} isTransparent label="알림" />
-          <IconButton
-            icon={<LogIn />}
-            isTransparent
-            label="로그인"
-            onClick={onLoginClick}
-          />
+          <Link href="/login">
+            <IconButton icon={<LogIn />} isTransparent label="로그인" />
+          </Link>
         </div>
       )}
     </header>

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -5,9 +5,12 @@ import {
   LogoLineIcon,
   SearchIcon,
   NotificationIcon,
+  DefaultProfileIcon,
 } from "@/components/common/Icons";
 import Searchbar from "@/components/Searchbar/Searchbar";
+import { useAuthStore } from "@/stores/useAuthStore";
 import { ArrowLeftIcon, LogIn, MenuIcon } from "lucide-react";
+import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -26,6 +29,7 @@ const Header = ({ onMenuClick }: HeaderProps) => {
     "/email-validation",
   ];
   const [isMobileSearchOpen, setIsMobileSearchOpen] = useState(false);
+  const { user } = useAuthStore();
 
   useEffect(() => {
     const handleResize = () => {
@@ -34,7 +38,6 @@ const Header = ({ onMenuClick }: HeaderProps) => {
         setIsMobileSearchOpen(false);
       }
     };
-
     window.addEventListener("resize", handleResize);
 
     return () => {
@@ -89,9 +92,24 @@ const Header = ({ onMenuClick }: HeaderProps) => {
             />
           </div>
           <IconButton icon={<NotificationIcon />} isTransparent label="알림" />
-          <Link href="/login">
-            <IconButton icon={<LogIn />} isTransparent label="로그인" />
-          </Link>
+          {user?.userId ? (
+            <Link href={`/profile/${user.userId}`}>
+              {user.profileImageUrl ? (
+                <Image
+                  src={user.profileImageUrl}
+                  alt="프로필 이미지"
+                  width={28}
+                  height={28}
+                />
+              ) : (
+                <DefaultProfileIcon className="rounded-full object-cover" />
+              )}
+            </Link>
+          ) : (
+            <Link href="/login">
+              <IconButton icon={<LogIn />} isTransparent label="로그인" />
+            </Link>
+          )}
         </div>
       )}
     </header>

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -100,6 +100,7 @@ const Header = ({ onMenuClick }: HeaderProps) => {
                   alt="프로필 이미지"
                   width={28}
                   height={28}
+                  className="rounded-full object-cover"
                 />
               ) : (
                 <DefaultProfileIcon className="rounded-full object-cover" />

--- a/src/components/layout/HeaderShell.tsx
+++ b/src/components/layout/HeaderShell.tsx
@@ -1,8 +1,14 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useState } from "react";
-import Header from "./Header/Header";
-import Sidebar from "./Sidebar/Sidebar";
+
+const Header = dynamic(() => import("./Header/Header"), {
+  ssr: false,
+});
+const Sidebar = dynamic(() => import("./Sidebar/Sidebar"), {
+  ssr: false,
+});
 
 export default function HeaderShell() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);

--- a/src/components/layout/HeaderShell.tsx
+++ b/src/components/layout/HeaderShell.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useState } from "react";
+import Header from "./Header/Header";
+import Sidebar from "./Sidebar/Sidebar";
+
+export default function HeaderShell() {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  return (
+    <>
+      <Header onMenuClick={() => setIsSidebarOpen(true)} />
+      <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
+    </>
+  );
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,39 +1,15 @@
-"use client";
-
-import { usePathname } from "next/navigation";
-import { ReactNode, useState } from "react";
-import Header from "./Header/Header";
-import Sidebar from "./Sidebar/Sidebar";
-import { useRouter } from "next/navigation";
+import { ReactNode } from "react";
+import HeaderShell from "./HeaderShell";
 
 interface LayoutProps {
   children: ReactNode;
 }
 
 const Layout = ({ children }: LayoutProps) => {
-  const router = useRouter();
-  const pathname = usePathname();
-  const hideHeaderRoutes = [
-    "/login",
-    "/signup",
-    "/password-forget",
-    "/password-reset",
-    "/email-validation",
-  ];
-
-  const shouldHideHeader = hideHeaderRoutes.includes(pathname);
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-
   return (
-    <div className="h-screen flex flex-col">
-      {!shouldHideHeader && (
-        <Header
-          onMenuClick={() => setIsSidebarOpen(true)}
-          onLoginClick={() => router.push("/login")}
-        />
-      )}
-      <Sidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
-      <main className="flex-1 overflow-y-auto">{children}</main>
+    <div className="flex flex-col h-screen">
+      <HeaderShell />
+      <main>{children}</main>
     </div>
   );
 };

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,4 +1,6 @@
 import { AuthCredentials, SignupCredentials } from "@/types/auth";
+import { client } from "../fetch/client";
+import { UserInfo } from "@/stores/useAuthStore";
 
 export const userSignup = async (
   credentials: SignupCredentials,
@@ -28,6 +30,20 @@ export const userLogin = async (
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(credentials),
+  });
+
+  const body = await res.json();
+
+  if (!res.ok) {
+    throw new Error(body.message ?? "로그인 실패");
+  }
+};
+
+export const userSocialLogin = async (accessToken: string): Promise<void> => {
+  const res = await fetch("/api/auth/signin/social", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ accessToken }),
   });
 
   const body = await res.json();
@@ -88,4 +104,8 @@ export const resetPassword = async (
   }
 
   return body.data.message;
+};
+
+export const fetchUser = async (): Promise<UserInfo> => {
+  return await client<UserInfo>("/api/users/my");
 };

--- a/src/providers/Providers.tsx
+++ b/src/providers/Providers.tsx
@@ -3,14 +3,19 @@
 import { ToastMessageProvider } from "./ToastMessageProvider";
 import AuthInitializer from "@/components/AuthInitializer";
 import { ToastMessageContainer } from "@/components/common/ToastMessage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
   return (
-    <ToastMessageProvider>
-      <AuthInitializer>
-        {children}
-        <ToastMessageContainer />
-      </AuthInitializer>
-    </ToastMessageProvider>
+    <QueryClientProvider client={queryClient}>
+      <ToastMessageProvider>
+        <AuthInitializer>
+          {children}
+          <ToastMessageContainer />
+        </AuthInitializer>
+      </ToastMessageProvider>
+    </QueryClientProvider>
   );
 }

--- a/src/providers/ReactQueryProvider.tsx
+++ b/src/providers/ReactQueryProvider.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { useState } from "react";
+
+export default function ReactQueryProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [client] = useState(() => new QueryClient());
+  return (
+    <QueryClientProvider client={client}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 export type AuthProvider = "LOCAL" | "KAKAO";
 
@@ -19,11 +20,19 @@ interface AuthState {
   setInitialized: () => void;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
-  user: null,
-  isInitialized: false,
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      user: null,
+      isInitialized: false,
 
-  setUser: (user) => set({ user }),
-  clearUser: () => set({ user: null }),
-  setInitialized: () => set({ isInitialized: true }),
-}));
+      setUser: (user) => set({ user }),
+      clearUser: () => set({ user: null }),
+      setInitialized: () => set({ isInitialized: true }),
+    }),
+    {
+      name: "auth-storage",
+      partialize: (state) => ({ user: state.user }), // 저장할 필드만 지정
+    },
+  ),
+);


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
로그인 사용자일 경우 헤더에 프로필 이미지 표시

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 로그인 사용자일 경우 헤더에 프로필 이미지가 표시되도록 했습니다.
- react query 적용했습니다.
- 새로고침 시 미로그인처럼 보이는 현상때문에 persist 적용했다가 Hydration오류 발생해서 헤더, 사이드바를 dynamic으로 로딩해오도록 변경했습니다.
- 로그인한 이후 user의 정보를 받아올 수 있도록 적용했습니다. 로그인 후 홈화면으로 이동했는데 /users/my를 호출하지 않아서 전체적으로 수정했습니다.


## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
|프로필 사진 있을 때(카카오 로그인)|프로필사진 없을 때|
|--|--|
|<img width="464" alt="스크린샷 2025-05-22 오후 8 43 33" src="https://github.com/user-attachments/assets/cfd1ee87-45fc-4520-b7d9-a19554032a70" />|<img width="390" alt="스크린샷 2025-05-22 오후 8 43 18" src="https://github.com/user-attachments/assets/7f8420f2-2247-424a-b52a-8189507c3b08" />|



## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->



## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
Layout에 "use client"를 사용하면 클라이언트 컴포넌트가 되는데 그럼 Next.js를 사용하는 의미가 없어지기때문에 해당 부분 고민하면서 헤더, 사이드바만 클라이언트 컴포넌트가 되도록 했습니다.
멘토링 이후 뭔가 신경쓸게 많아지니 시간이 좀 오래 걸렸네요.