### PR TITLE
홈화면 공통 헤더, 리스트 형식 공통 컴포넌트 UI 생성

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+import HomeComponent from "@/components/Home/HomeComponent";
+
 export default function HomePage() {
-  return <></>;
+  return <HomeComponent />;
 }

--- a/src/components/Home/HomeComponent.tsx
+++ b/src/components/Home/HomeComponent.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+const HomeComponent = () => {
+  // TODO: 배경색 빼기
+  return (
+    <div className="min-h-full flex pt-20 items-start justify-center bg-red-50">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full max-w-md px-4">
+        <div className="bg-white shadow rounded-xl p-4 text-center">
+          같이쓰자
+        </div>
+        <div className="bg-white shadow rounded-xl p-4 text-center">
+          자취일상
+        </div>
+        <div className="col-span-1 sm:col-span-2 bg-white shadow rounded-xl p-4 text-center">
+          아무거나샀어요
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HomeComponent;

--- a/src/components/Home/HomeComponent.tsx
+++ b/src/components/Home/HomeComponent.tsx
@@ -1,16 +1,24 @@
 import React from "react";
+import HomeSectionCard, { ListItem } from "./HomeSectionCard";
+import { SectionType } from "./SectionType";
 
 const HomeComponent = () => {
+  // TODO: 지우기
+  const dummyItems: ListItem[] = [
+    { title: "이사비 절약 공동구매 모집 중", timeAgo: "1시간 전" },
+    { title: "화장지 나눠써요 🙌", timeAgo: "2시간 전" },
+    { title: "택배 수령 부탁해요", timeAgo: "3시간 전" },
+    { title: "주방 세제 나눔합니다", timeAgo: "5시간 전" },
+    { title: "쓰레기봉투 공동 구매자 구해요", timeAgo: "6시간 전" },
+  ];
+
   // TODO: 배경색 빼기
   return (
-    <div className="min-h-full flex pt-20 items-start justify-center bg-red-50">
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full max-w-md px-4">
-        <div className="bg-white shadow rounded-xl p-4 text-center">
-          같이쓰자
-        </div>
-        <div className="bg-white shadow rounded-xl p-4 text-center">
-          자취일상
-        </div>
+    <div className="min-h-full flex pt-20 items-start justify-center bg-red-50 px-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-6 sm:gap-y-12 w-full max-w-4xl px-4">
+        <HomeSectionCard type={SectionType.TOGETHER} items={dummyItems} />
+        <HomeSectionCard type={SectionType.DAILY_LIFE} items={dummyItems} />
+
         <div className="col-span-1 sm:col-span-2 bg-white shadow rounded-xl p-4 text-center">
           아무거나샀어요
         </div>

--- a/src/components/Home/HomeSectionCard.tsx
+++ b/src/components/Home/HomeSectionCard.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import HomeSectionHeader from "./HomeSectionHeader";
+import { SectionType } from "./SectionType";
+import HomeSectionListItem from "./HomeSectionListItem";
+
+export interface ListItem {
+  title: string;
+  timeAgo: string;
+}
+
+interface HomeSectionProps {
+  type: SectionType;
+  items: ListItem[];
+}
+
+const HomeSectionCard = ({ type, items }: HomeSectionProps) => {
+  return (
+    <div>
+      <HomeSectionHeader type={type} />
+      <ul className="flex flex-col pt-3 gap-3 pl-4 pr-2">
+        {items.map((item, idx) => (
+          <HomeSectionListItem
+            key={idx}
+            title={item.title}
+            timeAge={item.timeAgo}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default HomeSectionCard;

--- a/src/components/Home/HomeSectionHeader.tsx
+++ b/src/components/Home/HomeSectionHeader.tsx
@@ -1,0 +1,26 @@
+import { SECTION_META, SectionType } from "./SectionType";
+import Link from "next/link";
+
+interface HomeSectionHeaderProps {
+  type: SectionType;
+}
+const HomeSectionHeader = ({ type }: HomeSectionHeaderProps) => {
+  const meta = SECTION_META[type];
+
+  return (
+    <div className="flex items-center justify-between h-10">
+      <div className="flex items-center justify-center gap-2">
+        {meta.icon}
+        <h2 className="text-xl font-bold">{meta.title}</h2>
+      </div>
+      <Link
+        href={meta.route}
+        className="flex items-center justify-center text-gray600"
+      >
+        <span className="text-sm">{"보러가기 >"}</span>
+      </Link>
+    </div>
+  );
+};
+
+export default HomeSectionHeader;

--- a/src/components/Home/HomeSectionListItem.tsx
+++ b/src/components/Home/HomeSectionListItem.tsx
@@ -1,0 +1,15 @@
+interface HomeSectionListItemProps {
+  title: string;
+  timeAge: string;
+}
+
+const HomeSectionListItem = ({ title, timeAge }: HomeSectionListItemProps) => {
+  return (
+    <li className="flex justify-between text-sm">
+      <span className="text-gray900">{title}</span>
+      <span className="text-gray600">{timeAge}</span>
+    </li>
+  );
+};
+
+export default HomeSectionListItem;

--- a/src/components/Home/SectionType.tsx
+++ b/src/components/Home/SectionType.tsx
@@ -1,0 +1,32 @@
+import { TogetherIcon, TipIcon, ShoppingBagIcon } from "../common/Icons";
+
+export enum SectionType {
+  TOGETHER = "together",
+  DAILY_LIFE = "dailyLife",
+  RANDOM_BUY = "randomBuy",
+}
+
+export const SECTION_META: Record<
+  SectionType,
+  {
+    title: string;
+    icon: React.ReactNode;
+    route: string;
+  }
+> = {
+  [SectionType.TOGETHER]: {
+    title: "같이 쓰자",
+    icon: <TogetherIcon />,
+    route: "/together",
+  },
+  [SectionType.DAILY_LIFE]: {
+    title: "자취 일상",
+    icon: <TipIcon />,
+    route: "/daily-life",
+  },
+  [SectionType.RANDOM_BUY]: {
+    title: "아무거나 샀어요",
+    icon: <ShoppingBagIcon />,
+    route: "/random-buy",
+  },
+};

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -9,7 +9,7 @@ const Layout = ({ children }: LayoutProps) => {
   return (
     <div className="flex flex-col h-screen">
       <HeaderShell />
-      <main>{children}</main>
+      <main className="flex-1">{children}</main>
     </div>
   );
 };


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
홈화면 공통 헤더, 리스트 형식 공통 컴포넌트 UI 생성했습니다.

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- SectionType을 생성하여 타입과 아이템만 주입하면 자동으로 UI가 그려질 수 있도록 했습니다.
- SectionType을 통해 홈 공통 헤더 UI 가 구분되도록 했습니다.
- 배경색이랑 더미데이터는 추후 삭제예정입니다!
- HomePage 자체가 SSR이 될 수 있도록 use client는 안쓸 수 있도록 컴포넌트들을 분리했습니다
  - HomeComonent - 홈화면 전체의 컴포넌트를 가짐
  - HomeSectionCard - 섹션별 카드
  - HomeSectionHeader - 홈화면 섹션 헤더
  - HomeSectionListItem - 리스트형식 아이템
- 내부에 있는 링크는 임시 링크입니다.


## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->

<img width="926" alt="image" src="https://github.com/user-attachments/assets/492f583d-2933-44af-b181-6d792501fe45" />


## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->



## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->


아무거나 샀어요가 추가되면 SectionCard 내에서 타입에 따라 그려지는 리스트가 다르게 할 예정입니다.