### PR TITLE
홈 아무거나 샀어요 이미지형 컴포넌트 추가

### DIFF
--- a/src/components/Home/HomeComponent.tsx
+++ b/src/components/Home/HomeComponent.tsx
@@ -1,15 +1,16 @@
 import React from "react";
-import HomeSectionCard, { ListItem } from "./HomeSectionCard";
+import HomeSectionCard from "./HomeSectionCard";
 import { SectionType } from "./SectionType";
+import { CommonPostItem } from "@/types/post";
 
 const HomeComponent = () => {
   // TODO: 지우기
-  const dummyItems: ListItem[] = [
-    { title: "이사비 절약 공동구매 모집 중", timeAgo: "1시간 전" },
-    { title: "화장지 나눠써요 🙌", timeAgo: "2시간 전" },
-    { title: "택배 수령 부탁해요", timeAgo: "3시간 전" },
-    { title: "주방 세제 나눔합니다", timeAgo: "5시간 전" },
-    { title: "쓰레기봉투 공동 구매자 구해요", timeAgo: "6시간 전" },
+  const dummyItems: CommonPostItem[] = [
+    { postId: 1, title: "이사비 절약 공동구매 모집 중", createAt: "1시간 전" },
+    { postId: 2, title: "화장지 나눠써요 🙌", createAt: "2시간 전" },
+    { postId: 3, title: "택배 수령 부탁해요", createAt: "3시간 전" },
+    { postId: 4, title: "주방 세제 나눔합니다", createAt: "5시간 전" },
+    { postId: 5, title: "쓰레기봉투 공동 구매자 구해요", createAt: "6시간 전" },
   ];
 
   // TODO: 배경색 빼기

--- a/src/components/Home/HomeComponent.tsx
+++ b/src/components/Home/HomeComponent.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import HomeSectionCard from "./HomeSectionCard";
 import { SectionType } from "./SectionType";
-import { CommonPostItem } from "@/types/post";
+import { CommonPostItem, ImagePostItem } from "@/types/post";
 
 const HomeComponent = () => {
   // TODO: 지우기
@@ -13,16 +13,72 @@ const HomeComponent = () => {
     { postId: 5, title: "쓰레기봉투 공동 구매자 구해요", createAt: "6시간 전" },
   ];
 
+  const imageDummyItems: ImagePostItem[] = [
+    {
+      postId: 1,
+      title: "이사비 절약 공동구매 모집 중",
+      content: "이사비 절약 공동구매 모집 중인데 함께하실 분",
+      thumbnailUrl:
+        "http://k.kakaocdn.net/dn/dPnHPP/btsKoj9P3g3/xRGh0kiZNlqmQ9eCEAnyfk/img_640x640.jpg",
+      likeCount: 1,
+      commentCount: 1,
+      writerProfileImage:
+        "http://k.kakaocdn.net/dn/dPnHPP/btsKoj9P3g3/xRGh0kiZNlqmQ9eCEAnyfk/img_640x640.jpg",
+      writerNickname: "테스터 1",
+      createAt: "1시간 전",
+    },
+    {
+      postId: 2,
+      title: "화장지 나눠써요 🙌",
+      content: "화장지 나눠 살 사람 모집 중 컴온컴온",
+      thumbnailUrl:
+        "http://k.kakaocdn.net/dn/dPnHPP/btsKoj9P3g3/xRGh0kiZNlqmQ9eCEAnyfk/img_640x640.jpg",
+      likeCount: 1,
+      commentCount: 1,
+      writerProfileImage:
+        "http://k.kakaocdn.net/dn/dPnHPP/btsKoj9P3g3/xRGh0kiZNlqmQ9eCEAnyfk/img_640x640.jpg",
+      writerNickname: "테스터 1",
+      createAt: "1시간 전",
+    },
+    {
+      postId: 3,
+      title: "택배 수령 부탁해요",
+      content: "GS25에서 제 택배 수령해달라고 하면 좀 염치없나요",
+      thumbnailUrl:
+        "http://k.kakaocdn.net/dn/dPnHPP/btsKoj9P3g3/xRGh0kiZNlqmQ9eCEAnyfk/img_640x640.jpg",
+      likeCount: 1,
+      commentCount: 1,
+      writerProfileImage:
+        "http://k.kakaocdn.net/dn/dPnHPP/btsKoj9P3g3/xRGh0kiZNlqmQ9eCEAnyfk/img_640x640.jpg",
+      writerNickname: "테스터 1",
+      createAt: "1시간 전",
+    },
+    {
+      postId: 4,
+      title: "주방 세제 나눔합니다",
+      content: "프로쉬 실수로 너무 많이 사버림",
+      thumbnailUrl:
+        "http://k.kakaocdn.net/dn/dPnHPP/btsKoj9P3g3/xRGh0kiZNlqmQ9eCEAnyfk/img_640x640.jpg",
+      likeCount: 100,
+      commentCount: 3,
+      writerProfileImage:
+        "http://k.kakaocdn.net/dn/dPnHPP/btsKoj9P3g3/xRGh0kiZNlqmQ9eCEAnyfk/img_640x640.jpg",
+      writerNickname: "테스터 1",
+      createAt: "1시간 전",
+    },
+  ];
+
   // TODO: 배경색 빼기
   return (
-    <div className="min-h-full flex pt-20 items-start justify-center bg-red-50 px-4">
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-6 sm:gap-y-12 w-full max-w-4xl px-4">
+    <div className="min-h-full flex pt-20 items-start justify-center px-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-6 sm:gap-y-12 w-full max-w-3xl px-4">
         <HomeSectionCard type={SectionType.TOGETHER} items={dummyItems} />
         <HomeSectionCard type={SectionType.DAILY_LIFE} items={dummyItems} />
-
-        <div className="col-span-1 sm:col-span-2 bg-white shadow rounded-xl p-4 text-center">
-          아무거나샀어요
-        </div>
+        <HomeSectionCard
+          type={SectionType.RANDOM_BUY}
+          items={imageDummyItems}
+          className="sm:col-span-2"
+        />
       </div>
     </div>
   );

--- a/src/components/Home/HomeSectionCard.tsx
+++ b/src/components/Home/HomeSectionCard.tsx
@@ -2,15 +2,11 @@ import React from "react";
 import HomeSectionHeader from "./HomeSectionHeader";
 import { SectionType } from "./SectionType";
 import HomeSectionListItem from "./HomeSectionListItem";
-
-export interface ListItem {
-  title: string;
-  timeAgo: string;
-}
+import { CommonPostItem } from "@/types/post";
 
 interface HomeSectionProps {
   type: SectionType;
-  items: ListItem[];
+  items: CommonPostItem[];
 }
 
 const HomeSectionCard = ({ type, items }: HomeSectionProps) => {
@@ -18,11 +14,11 @@ const HomeSectionCard = ({ type, items }: HomeSectionProps) => {
     <div>
       <HomeSectionHeader type={type} />
       <ul className="flex flex-col pt-3 gap-3 pl-4 pr-2">
-        {items.map((item, idx) => (
+        {items.map((item) => (
           <HomeSectionListItem
-            key={idx}
+            key={item.postId}
             title={item.title}
-            timeAge={item.timeAgo}
+            timeAge={item.createAt}
           />
         ))}
       </ul>

--- a/src/components/Home/HomeSectionCard.tsx
+++ b/src/components/Home/HomeSectionCard.tsx
@@ -2,26 +2,39 @@ import React from "react";
 import HomeSectionHeader from "./HomeSectionHeader";
 import { SectionType } from "./SectionType";
 import HomeSectionListItem from "./HomeSectionListItem";
-import { CommonPostItem } from "@/types/post";
+import { CommonPostItem, ImagePostItem } from "@/types/post";
+import PostImageCard from "../common/SectionCards/PostImageCard";
+import clsx from "clsx";
 
 interface HomeSectionProps {
   type: SectionType;
-  items: CommonPostItem[];
+  items: (CommonPostItem | ImagePostItem)[];
+  className?: string;
 }
 
-const HomeSectionCard = ({ type, items }: HomeSectionProps) => {
+const isImagePostItemArray = (
+  arr: (CommonPostItem | ImagePostItem)[],
+): arr is ImagePostItem[] => arr.length > 0 && "thumbnailUrl" in arr[0];
+
+const HomeSectionCard = ({ type, items, className }: HomeSectionProps) => {
+  const isImage = isImagePostItemArray(items);
+
   return (
-    <div>
+    <div className={clsx("w-full", className)}>
       <HomeSectionHeader type={type} />
-      <ul className="flex flex-col pt-3 gap-3 pl-4 pr-2">
-        {items.map((item) => (
-          <HomeSectionListItem
-            key={item.postId}
-            title={item.title}
-            timeAge={item.createAt}
-          />
-        ))}
-      </ul>
+      {isImage ? (
+        <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-2 pt-4">
+          {items.map((item) => (
+            <PostImageCard key={item.postId} {...item} />
+          ))}
+        </ul>
+      ) : (
+        <ul className="flex flex-col pt-3 gap-3 pl-4 pr-2">
+          {items.map((item) => (
+            <HomeSectionListItem key={item.postId} {...item} />
+          ))}
+        </ul>
+      )}
     </div>
   );
 };

--- a/src/components/Home/HomeSectionHeader.tsx
+++ b/src/components/Home/HomeSectionHeader.tsx
@@ -17,7 +17,7 @@ const HomeSectionHeader = ({ type }: HomeSectionHeaderProps) => {
         href={meta.route}
         className="flex items-center justify-center text-gray600"
       >
-        <span className="text-sm">{"보러가기 >"}</span>
+        <span className="text-xs">{"보러가기 >"}</span>
       </Link>
     </div>
   );

--- a/src/components/Home/HomeSectionListItem.tsx
+++ b/src/components/Home/HomeSectionListItem.tsx
@@ -1,13 +1,10 @@
-interface HomeSectionListItemProps {
-  title: string;
-  timeAge: string;
-}
+import { CommonPostItem } from "@/types/post";
 
-const HomeSectionListItem = ({ title, timeAge }: HomeSectionListItemProps) => {
+const HomeSectionListItem = ({ title, createAt }: CommonPostItem) => {
   return (
     <li className="flex justify-between text-sm">
       <span className="text-gray900">{title}</span>
-      <span className="text-gray600">{timeAge}</span>
+      <span className="text-gray600">{createAt}</span>
     </li>
   );
 };

--- a/src/components/common/SectionCards/PostImageCard.tsx
+++ b/src/components/common/SectionCards/PostImageCard.tsx
@@ -1,0 +1,54 @@
+import { ImagePostItem } from "@/types/post";
+import Image from "next/image";
+
+const PostImageCard = ({
+  title,
+  content,
+  thumbnailUrl,
+  likeCount,
+  commentCount,
+  writerProfileImage,
+  writerNickname,
+}: ImagePostItem) => {
+  return (
+    <div>
+      <div className="relative w-full aspect-square">
+        <Image src={thumbnailUrl} alt={title} fill className="object-cover" />
+      </div>
+      {/* 본문 */}
+      <div className="pt-2 px-1 flex flex-col gap-2">
+        {/* 작성자 */}
+        <div className="flex items-center gap-1">
+          <Image
+            src={writerProfileImage}
+            alt={writerNickname}
+            width={20}
+            height={20}
+            className="rounded-full object-cover"
+          />
+          <span className="text-sm text-gray600 whitespace-nowrap">
+            {writerNickname}
+          </span>
+        </div>
+        {/* 컨텐츠 */}
+        <div className="flex flex-col gap-0">
+          <h3 className="text-base font-semibold text-gray900 line-clamp-2">
+            {title}
+          </h3>
+          <h4 className=" text-sm text-gray600 line-clamp-1">{content}</h4>
+        </div>
+        {/* 좋아요, 댓글 */}
+        <div className="flex items-center justify-end pt-2 pr-1 text-xs font-light gap-2">
+          <span>
+            좋아요 <span className="font-bold">{likeCount}</span>개
+          </span>
+          <span>
+            댓글 <span className="font-bold">{commentCount}</span>개
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PostImageCard;

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,0 +1,14 @@
+export interface CommonPostItem {
+  postId: number;
+  title: string;
+  createAt: string;
+}
+
+export interface ImagePostItem extends CommonPostItem {
+  content: string;
+  thumbnailUrl: string;
+  likeCount: number;
+  commentCount: number;
+  writerProfileImage: string;
+  writerNickname: string;
+}


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
홈의 아무거나 샀어요 이미지형 컴포넌트 UI를 추가했습니다.

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 아무거나 샀어요는 리스트?에서도 사용할 수 있을 것 같아 SectionCards 폴더를 만들어 내부에 생성했습니다. (카테고리 리스트에서 리스트용 컴포넌트 생성 예정)
- 스웨거에 모델 형식이 나와있길래 HomeSectionListItem의 형식도 변경했습니다.
- SectionType에 따라 아이템 분기처리를 하려고 했는데 CommonPostItem과 ImagePostItem의 모델을 같이 쓰지 못해서 isImagePostItemArray(thumbnail 유무)로 카드형, 리스트형 보이도록 조건을 추가했습니다.
- 제목은 2줄까지 content는 1줄만 보여지도록 했습니다.


## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
<img width="1401" alt="스크린샷 2025-05-23 오후 3 06 35" src="https://github.com/user-attachments/assets/4d4e9502-10bb-4ec4-9192-becdb1cd2a6e" />



## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->



## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
