### PR TITLE
임시 저장 불러오기 전 이미 에디터에 표시되는 버그 수정 및 임시 저장 시 카테고리와 태그 제거

### DIFF
--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -275,7 +275,7 @@ export default function PostEditor() {
               return;
             }
             const content = instance.getMarkdown();
-            saveDraft({ title, mainCategory, subCategory, content });
+            saveDraft({ title, content });
             showToastMessage({ message: "임시 저장 완료", type: "info" });
           }}
         >

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -138,11 +138,14 @@ export default function PostEditor() {
   // 에디터 내부 초기화
   useEffect(() => {
     const editor = editorRef.current?.getInstance();
-    if (editor && !content) {
+    if (!editor) return;
+  
+    if (content !== undefined && content !== null) {
+      editor.setMarkdown(content); // draft 또는 직접 작성 내용 반영
+    } else {
       editor.setMarkdown(""); // 진짜 초기화
     }
-    // eslint-disable-next-line
-  }, []);
+  }, [content]);
 
   // 글 작성
   const handleSubmit = async () => {

--- a/src/components/editor/PostEditor.tsx
+++ b/src/components/editor/PostEditor.tsx
@@ -135,17 +135,20 @@ export default function PostEditor() {
 
   const restore = useRestoreDraft(editorRef); // 임시 저장 불러오기
 
-  // 에디터 내부 초기화
+  // 에디터 내부 초기화 로직
   useEffect(() => {
     const editor = editorRef.current?.getInstance();
     if (!editor) return;
-  
-    if (content !== undefined && content !== null) {
-      editor.setMarkdown(content); // draft 또는 직접 작성 내용 반영
-    } else {
-      editor.setMarkdown(""); // 진짜 초기화
+
+    // 준비 완료되기 전에는 항상 빈 화면
+    if (!restore.isReady) {
+      editor.setMarkdown("");
+      return;
     }
-  }, [content]);
+
+    // 준비 완료 후에는 store의 content 반영
+    editor.setMarkdown(content || "");
+  }, [restore.isReady, content]);
 
   // 글 작성
   const handleSubmit = async () => {
@@ -234,7 +237,7 @@ export default function PostEditor() {
       {/* 제목 입력창 */}
       <input
         type="text"
-        value={title}
+        value={restore.isReady ? title : ""}
         onChange={(e) => setTitle(e.target.value)}
         placeholder="제목을 입력하세요"
         className="w-full h-[60px] text-2xl font-semibold outline-none placeholder-gray-400 mb-6 px-3 py-2 rounded-md bg-white shadow-[0_1px_4px_rgba(0,0,0,0.1)] focus:shadow-[0_2px_6px_rgba(0,0,0,0.2)] transition"
@@ -244,7 +247,7 @@ export default function PostEditor() {
       <Editor
         ref={editorRef}
         language="ko-KR"
-        initialValue={content || ""}
+        initialValue=""
         previewStyle="vertical"
         height="420px"
         initialEditType="wysiwyg"

--- a/src/hooks/useAutoSaveDraft.ts
+++ b/src/hooks/useAutoSaveDraft.ts
@@ -2,20 +2,15 @@ import { useEffect, useRef, MutableRefObject } from "react";
 import { usePostStore } from "@/stores/usePostStore";
 import { Editor } from "@toast-ui/react-editor";
 import { saveDraft } from "@/utils/editorStorage";
-import { MainCategory, SubCategoryValue } from "@/types/category";
 
 export function useAutoSaveDraft(editorRef: MutableRefObject<Editor | null>) {
-  const { title, mainCategory, subCategory } = usePostStore();
+  const { title } = usePostStore();
 
   const prevDataRef = useRef<{
     title: string;
-    mainCategory: MainCategory | null;
-    subCategory: SubCategoryValue | null;
     content: string;
   }>({
     title: "",
-    mainCategory: null,
-    subCategory: null,
     content: "",
   });
 
@@ -25,34 +20,26 @@ export function useAutoSaveDraft(editorRef: MutableRefObject<Editor | null>) {
 
       const hasChanged =
         prevDataRef.current.title !== title ||
-        prevDataRef.current.mainCategory !== mainCategory ||
-        prevDataRef.current.subCategory !== subCategory ||
         prevDataRef.current.content !== content;
 
       if (hasChanged) {
         console.log("💾 변경 감지, 임시 저장:", {
           title,
-          mainCategory,
-          subCategory,
           content,
         });
 
         saveDraft({
           title,
-          mainCategory,
-          subCategory,
           content,
         });
 
         prevDataRef.current = {
           title,
-          mainCategory,
-          subCategory,
           content,
         };
       }
     }, 10000);
 
     return () => clearInterval(interval);
-  }, [title, mainCategory, subCategory]);
+  }, [title, editorRef]);
 }

--- a/src/hooks/useRestoreDraft.ts
+++ b/src/hooks/useRestoreDraft.ts
@@ -5,9 +5,7 @@ import type { Editor } from "@toast-ui/react-editor";
 import type { PostDraft } from "@/types/editor";
 
 export const useRestoreDraft = (editorRef: React.RefObject<Editor | null>) => {
-  const { setMainCategory, setSubCategory, setTitle, setContent, resetPost } =
-    usePostStore();
-
+  const { setTitle, setContent, resetPost } = usePostStore();
   const [isOpen, setIsOpen] = useState(false);
   const [draft, setDraft] = useState<PostDraft | null>(null);
   const [isReady, setIsReady] = useState(false);
@@ -26,8 +24,6 @@ export const useRestoreDraft = (editorRef: React.RefObject<Editor | null>) => {
   // "예" 선택 시
   const handleConfirm = () => {
     if (draft) {
-      setMainCategory(draft.mainCategory);
-      setSubCategory(draft.subCategory);
       setTitle(draft.title);
       setContent(draft.content);
       editorRef.current?.getInstance().setMarkdown(draft.content);

--- a/src/hooks/useRestoreDraft.ts
+++ b/src/hooks/useRestoreDraft.ts
@@ -1,11 +1,13 @@
 import { useState, useEffect } from "react";
-import { loadDraft } from "@/utils/editorStorage";
+import { loadDraft, clearDraft } from "@/utils/editorStorage";
 import { usePostStore } from "@/stores/usePostStore";
 import type { Editor } from "@toast-ui/react-editor";
 import type { PostDraft } from "@/types/editor";
 
 export const useRestoreDraft = (editorRef: React.RefObject<Editor | null>) => {
-  const { setTitle, setMainCategory, setSubCategory } = usePostStore();
+  const { setMainCategory, setSubCategory, setTitle, setContent, resetPost } =
+    usePostStore();
+
   const [isOpen, setIsOpen] = useState(false);
   const [draft, setDraft] = useState<PostDraft | null>(null);
 
@@ -18,17 +20,26 @@ export const useRestoreDraft = (editorRef: React.RefObject<Editor | null>) => {
     });
   }, []);
 
+  // "예" 선택 시
   const handleConfirm = () => {
     if (draft) {
-      setTitle(draft.title);
       setMainCategory(draft.mainCategory);
       setSubCategory(draft.subCategory);
+      setTitle(draft.title);
+      setContent(draft.content);
       editorRef.current?.getInstance().setMarkdown(draft.content);
+      clearDraft();
     }
     setIsOpen(false);
   };
 
-  const handleClose = () => setIsOpen(false);
+  // "아니오" 선택 시
+  const handleClose = () => {
+    editorRef.current?.getInstance().setMarkdown("");
+    resetPost(); // 상태 초기화
+    clearDraft(); // indexedDB 삭제
+    setIsOpen(false); // 모달 닫기
+  };
 
   return { isOpen, onClose: handleClose, onConfirm: handleConfirm };
 };

--- a/src/hooks/useRestoreDraft.ts
+++ b/src/hooks/useRestoreDraft.ts
@@ -10,12 +10,15 @@ export const useRestoreDraft = (editorRef: React.RefObject<Editor | null>) => {
 
   const [isOpen, setIsOpen] = useState(false);
   const [draft, setDraft] = useState<PostDraft | null>(null);
+  const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
     loadDraft().then((saved) => {
       if (saved) {
         setDraft(saved);
         setIsOpen(true); // 모달 열기
+      } else {
+        setIsReady(true);
       }
     });
   }, []);
@@ -31,6 +34,7 @@ export const useRestoreDraft = (editorRef: React.RefObject<Editor | null>) => {
       clearDraft();
     }
     setIsOpen(false);
+    setIsReady(true);
   };
 
   // "아니오" 선택 시
@@ -39,7 +43,8 @@ export const useRestoreDraft = (editorRef: React.RefObject<Editor | null>) => {
     resetPost(); // 상태 초기화
     clearDraft(); // indexedDB 삭제
     setIsOpen(false); // 모달 닫기
+    setIsReady(true);
   };
 
-  return { isOpen, onClose: handleClose, onConfirm: handleConfirm };
+  return { isOpen, onClose: handleClose, onConfirm: handleConfirm, isReady };
 };

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -1,8 +1,4 @@
-import type { MainCategory, SubCategoryValue } from "@/types/category";
-
 export interface PostDraft {
   title: string;
-  mainCategory: MainCategory | null;
-  subCategory: SubCategoryValue | null;
   content: string;
 }

--- a/src/utils/editorStorage.ts
+++ b/src/utils/editorStorage.ts
@@ -19,6 +19,12 @@ export async function loadDraft(): Promise<PostDraft | null> {
   });
 }
 
+export async function clearDraft(): Promise<void> {
+  const db = await openDB();
+  const tx = db.transaction("drafts", "readwrite");
+  tx.objectStore("drafts").delete(STORE_KEY);
+}
+
 async function openDB(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const req = indexedDB.open(DB_NAME, 1);


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
임시 저장 불러오기 전 이미 에디터에 표시되는 버그 수정 및 임시 저장 시 카테고리와 태그 제거

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 임시 저장 시 카테고리와 태그 정보를 저장하지 않도록 수정했습니다
- 자동 임시 저장 시 카테고리와 태그 정보를 저장하지 않도록 수정했습니다
- 에디터 접속 시 임시 저장한 내용이 먼저 보이지 않도록 수정했습니다
- 임시 저장 불러오기 모달에서 "아니오"를 누른 경우 임시 저장한 내용 자체를 삭제하도록 수정했습니다


## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->



## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [ ] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->
로컬에서 에디터 페이지 테스트


## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
구조가 바뀌면서 메인 카테고리가 보이지 않기 때문에 카테고리와 태그를 저장하면
오히려 버그날 확률이 높다는 생각이 들어서 아예 제거를 했습니다
이 부분은 다른 의견 있으시면 말씀 부탁드립니다

일단 불러오기 전 에디터 초기화랑 불러오기 모달은 작동이 잘 될 것 같은데 
배포 시 또 살펴봐야겠습니다 ㅠ