### PR TITLE
Feat/notification : 알림모달 컴포넌트 ui, 헤더 알림버튼 누를 시 토글

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -124,7 +124,7 @@ const Header = ({ onMenuClick }: HeaderProps) => {
           />
           <div className="relative">
             {isNotificationOpen && (
-              <div className="absolute top-full right-0 mt-2 z-50">
+              <div className="absolute top-full right-0 mt-6 z-50">
                 <NotificationModal />
               </div>
             )}

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -14,6 +14,7 @@ import {
   SearchIcon,
 } from "@/components/common/Icons";
 import Searchbar from "@/components/Searchbar/Searchbar";
+import NotificationModal from "@/components/notification/NotificationModal";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { getProfileImageUrl } from "@/utils/image";
 import useSse from "@/hooks/useSse";
@@ -36,7 +37,7 @@ const Header = ({ onMenuClick }: HeaderProps) => {
     "/email-validation",
     "/policy/terms",
     "/policy/privacy",
-    "/map"
+    "/map",
   ];
 
   // 검색창 숨김 경로 시작
@@ -47,6 +48,8 @@ const Header = ({ onMenuClick }: HeaderProps) => {
 
   // SSE 연결 시도
   useSse();
+
+  const [isNotificationOpen, setIsNotificationOpen] = useState(false);
 
   useEffect(() => {
     const handleResize = () => {
@@ -117,7 +120,15 @@ const Header = ({ onMenuClick }: HeaderProps) => {
             icon={<NotificationIcon className="w-6 h-6" />}
             isTransparent
             label="알림"
+            onClick={() => setIsNotificationOpen((prev) => !prev)}
           />
+          <div className="relative">
+            {isNotificationOpen && (
+              <div className="absolute top-full right-0 mt-2 z-50">
+                <NotificationModal />
+              </div>
+            )}
+          </div>
           {user?.userId ? (
             <Link href={`/profile/${user.userId}`}>
               <Image

--- a/src/components/notification/NotificationHeader.tsx
+++ b/src/components/notification/NotificationHeader.tsx
@@ -2,7 +2,7 @@
 
 const NotificationHeader = () => {
   return (
-    <div className="flex items-center justify-between px-4 py-2 border-b border-gray-200">
+    <div className="flex items-center justify-between h-[50px] px-4 py-2 border-b border-gray-200">
       <span>알림</span>
       <button>전체 읽기</button>
     </div>

--- a/src/components/notification/NotificationHeader.tsx
+++ b/src/components/notification/NotificationHeader.tsx
@@ -2,7 +2,7 @@
 
 const NotificationHeader = () => {
   return (
-    <div>
+    <div className="flex items-center justify-between px-4 py-2 border-b border-gray-200">
       <span>알림</span>
       <button>전체 읽기</button>
     </div>

--- a/src/components/notification/NotificationHeader.tsx
+++ b/src/components/notification/NotificationHeader.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+const NotificationHeader = () => {
+  return (
+    <div>
+      <span>알림</span>
+      <button>전체 읽기</button>
+    </div>
+  );
+};
+
+export default NotificationHeader;

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+const NotificationItem = () => {
+  return <div></div>;
+};
+
+export default NotificationItem;

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -6,6 +6,7 @@ type NotificationItemProps = {
   createdAt: string;
   comment?: string;
   thumbnailImage?: string;
+  isRead: boolean;
 };
 
 const NotificationItem = ({
@@ -14,11 +15,15 @@ const NotificationItem = ({
   createdAt,
   comment,
   thumbnailImage,
+  isRead,
 }: NotificationItemProps) => {
   return (
     <div className="flex items-center">
       {/* 읽음표시 img */}
-      <span className="w-1 h-1 rounded-full bg-purple-500 mt-1 mr-2" />
+      <span
+        className="inline-block w-2 h-2 rounded-full bg-purple-500 mt-1 mr-2"
+        style={{ visibility: isRead ? "hidden" : "visible" }}
+      />
 
       <div className="flex">
         {/* 알림액션 한 상대유저의 프로필이미지 */}

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -18,10 +18,10 @@ const NotificationItem = ({
   isRead,
 }: NotificationItemProps) => {
   return (
-    <div className="flex items-center h-[78px] mb-1">
+    <div className="flex items-center h-[78px] mb-1 mt-1">
       {/* 읽음표시 img */}
       <span
-        className="inline-block w-2 h-2 rounded-full bg-purple-500 mt-1 mr-2"
+        className="inline-block ml-2 mr-2 w-1 h-1 rounded-full bg-purple-500"
         style={{ visibility: isRead ? "hidden" : "visible" }}
       />
 

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -1,7 +1,24 @@
 "use client";
 
 const NotificationItem = () => {
-  return <div></div>;
+  return (
+    <div>
+      {/* 읽음표시 img */}
+      <img />
+      <div>
+        {/* 알림액션 한 상대유저의 프로필이미지 */}
+        <img />
+        <div>
+          <div>
+            <span>알림 내용</span>
+            <span>알림 생성 시각</span>
+          </div>
+          {/* 게시물 썸네일 img (게시물 좋아요일때만) */}
+          <img />
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default NotificationItem;

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -1,20 +1,36 @@
 "use client";
 
-const NotificationItem = () => {
+type NotificationType = "LIKE" | "FOLLOW" | "COMMENT";
+
+const NotificationItem = ({ type }: { type: NotificationType }) => {
   return (
-    <div>
+    <div className="flex">
       {/* 읽음표시 img */}
       <img />
       <div>
         {/* 알림액션 한 상대유저의 프로필이미지 */}
-        <img />
-        <div>
+        <img alt="프로필이미지" />
+
+        {/* (조건부) 알림 텍스트 + 썸네일 */}
+        <div className="flex">
           <div>
-            <span>알림 내용</span>
-            <span>알림 생성 시각</span>
+            <span>상대유저</span>
+            {type === "LIKE" && (
+              <span> 님이 회원님의 게시글을 좋아합니다.</span>
+            )}
+            {type === "FOLLOW" && (
+              <span> 님이 회원님을 팔로우하기 시작했습니다.</span>
+            )}
+            {type === "COMMENT" && (
+              <>
+                <span> 님이 댓글을 남겼습니다. : </span>
+                <span>와 자취꿀템 인정 ~ </span>
+              </>
+            )}
+            <span> 5분 전</span>
           </div>
           {/* 게시물 썸네일 img (게시물 좋아요일때만) */}
-          <img />
+          {type === "LIKE" && <img alt="썸네일이미지" />}
         </div>
       </div>
     </div>

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -22,7 +22,11 @@ const NotificationItem = ({
 
       <div className="flex">
         {/* 알림액션 한 상대유저의 프로필이미지 */}
-        <img alt="프로필이미지" />
+        <img
+          src="/icons/defaultProfile.svg"
+          alt="프로필이미지"
+          className="w-10 h-10 rounded-full object-cover"
+        />
 
         {/* (조건부) 알림 텍스트 + 썸네일 */}
         <div className="flex">
@@ -43,7 +47,13 @@ const NotificationItem = ({
             <span> {createdAt}</span>
           </div>
           {/* 게시물 썸네일 img (게시물 좋아요일때만) */}
-          {type === "LIKE" && <img src={thumbnailImage} alt="썸네일이미지" />}
+          {type === "LIKE" && (
+            <img
+              src={thumbnailImage || "/icons/placeholderImage.svg"}
+              alt="썸네일 이미지"
+              className="w-16 h-16 object-cover rounded"
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -18,7 +18,7 @@ const NotificationItem = ({
   isRead,
 }: NotificationItemProps) => {
   return (
-    <div className="flex items-center">
+    <div className="flex items-center h-[80px]">
       {/* 읽음표시 img */}
       <span
         className="inline-block w-2 h-2 rounded-full bg-purple-500 mt-1 mr-2"

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -18,8 +18,9 @@ const NotificationItem = ({
   return (
     <div className="flex">
       {/* 읽음표시 img */}
-      <img />
-      <div>
+      <img alt="읽 " />
+
+      <div className="flex">
         {/* 알림액션 한 상대유저의 프로필이미지 */}
         <img alt="프로필이미지" />
 

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -18,14 +18,14 @@ const NotificationItem = ({
   isRead,
 }: NotificationItemProps) => {
   return (
-    <div className="flex items-center h-[80px]">
+    <div className="flex items-center h-[78px] mb-1">
       {/* 읽음표시 img */}
       <span
         className="inline-block w-2 h-2 rounded-full bg-purple-500 mt-1 mr-2"
         style={{ visibility: isRead ? "hidden" : "visible" }}
       />
 
-      <div className="flex">
+      <div className="flex items-center">
         {/* 알림액션 한 상대유저의 프로필이미지 */}
         <img
           src="/icons/defaultProfile.svg"
@@ -34,7 +34,7 @@ const NotificationItem = ({
         />
 
         {/* (조건부) 알림 텍스트 + 썸네일 */}
-        <div className="flex">
+        <div className="flex items-center ml-2 mr-2">
           <div>
             <span>{username}</span>
             {type === "LIKE" && (
@@ -56,7 +56,7 @@ const NotificationItem = ({
             <img
               src={thumbnailImage || "/icons/placeholderImage.svg"}
               alt="썸네일 이미지"
-              className="w-16 h-16 object-cover rounded"
+              className="w-14 h-14 object-cover rounded ml-2"
             />
           )}
         </div>

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -1,8 +1,20 @@
 "use client";
 
-type NotificationType = "LIKE" | "FOLLOW" | "COMMENT";
+type NotificationItemProps = {
+  type: "LIKE" | "FOLLOW" | "COMMENT";
+  username: string;
+  createdAt: string;
+  comment?: string;
+  thumbnailImage?: string;
+};
 
-const NotificationItem = ({ type }: { type: NotificationType }) => {
+const NotificationItem = ({
+  type,
+  username,
+  createdAt,
+  comment,
+  thumbnailImage,
+}: NotificationItemProps) => {
   return (
     <div className="flex">
       {/* 읽음표시 img */}
@@ -14,7 +26,7 @@ const NotificationItem = ({ type }: { type: NotificationType }) => {
         {/* (조건부) 알림 텍스트 + 썸네일 */}
         <div className="flex">
           <div>
-            <span>상대유저</span>
+            <span>{username}</span>
             {type === "LIKE" && (
               <span> 님이 회원님의 게시글을 좋아합니다.</span>
             )}
@@ -24,13 +36,13 @@ const NotificationItem = ({ type }: { type: NotificationType }) => {
             {type === "COMMENT" && (
               <>
                 <span> 님이 댓글을 남겼습니다. : </span>
-                <span>와 자취꿀템 인정 ~ </span>
+                <span>{comment}</span>
               </>
             )}
-            <span> 5분 전</span>
+            <span> {createdAt}</span>
           </div>
           {/* 게시물 썸네일 img (게시물 좋아요일때만) */}
-          {type === "LIKE" && <img alt="썸네일이미지" />}
+          {type === "LIKE" && <img src={thumbnailImage} alt="썸네일이미지" />}
         </div>
       </div>
     </div>

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -16,9 +16,9 @@ const NotificationItem = ({
   thumbnailImage,
 }: NotificationItemProps) => {
   return (
-    <div className="flex">
+    <div className="flex items-center">
       {/* 읽음표시 img */}
-      <img alt="읽 " />
+      <span className="w-1 h-1 rounded-full bg-purple-500 mt-1 mr-2" />
 
       <div className="flex">
         {/* 알림액션 한 상대유저의 프로필이미지 */}

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -12,19 +12,22 @@ const NotificationModal = () => {
       createdAt: "3분 전",
       comment: "이건 진짜 꿀템이네요!",
       thumbnailImage: "/images/post/uuid4.png",
+      isRead: false,
     },
     {
       id: 3,
       type: "LIKE" as const,
       username: "자취왕",
       createdAt: "7분 전",
-      thumbnailImage: "/images/post/uuid3.png",
+      //   thumbnailImage: "/images/post/uuid3.png",
+      isRead: true,
     },
     {
       id: 2,
       type: "FOLLOW" as const,
       username: "맛잘알",
       createdAt: "15분 전",
+      isRead: true,
     },
     {
       id: 1,
@@ -33,11 +36,12 @@ const NotificationModal = () => {
       createdAt: "30분 전",
       comment: "레시피 공유 가능할까요?",
       thumbnailImage: "/images/post/uuid1.png",
+      isRead: false,
     },
   ];
 
   return (
-    <div className="w-[360px] h-[360px] bg-white z-50 border-t border-gray-100 rounded-xl shadow-md p-2">
+    <div className="w-[420px] h-[360px] bg-white z-50 border-t border-gray-100 rounded-xl shadow-md p-2">
       <header>
         <NotificationHeader />
       </header>
@@ -50,6 +54,7 @@ const NotificationModal = () => {
             createdAt={noti.createdAt}
             comment={noti.comment}
             thumbnailImage={noti.thumbnailImage}
+            isRead={noti.isRead}
           />
         ))}
       </div>

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -49,11 +49,11 @@ const NotificationModal = () => {
   ];
 
   return (
-    <div className="w-[420px] h-[360px] bg-white z-50 border-t border-gray-100 rounded-xl shadow-md p-1">
+    <div className="w-[420px] h-[360px] bg-white z-50 border-t border-gray-100 rounded-xl shadow-md p-1 overflow-hidden">
       <header>
         <NotificationHeader />
       </header>
-      <div className="h-[310px] overflow-y-auto pt-3 pb-4">
+      <div className="h-[310px] overflow-y-auto pt-1 pb-3">
         {dummyNotifications.map((noti) => (
           <NotificationItem
             key={noti.id}

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import NotificationHeader from "./NotificationHeader";
+import NotificationItem from "./NotificationItem";
+
+const NotificationModal = () => {
+  return (
+    <div>
+      <header>
+        <NotificationHeader />
+      </header>
+      <div>
+        {/* map으로 돌려야함 */}
+        <NotificationItem />
+      </div>
+    </div>
+  );
+};
+
+export default NotificationModal;

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -11,7 +11,7 @@ const NotificationModal = () => {
       </header>
       <div>
         {/* map으로 돌려야함 */}
-        <NotificationItem />
+        <NotificationItem type="LIKE" />
       </div>
     </div>
   );

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -42,8 +42,16 @@ const NotificationModal = () => {
         <NotificationHeader />
       </header>
       <div>
-        {/* map으로 돌려야함 */}
-        <NotificationItem type="COMMENT" />
+        {dummyNotifications.map((noti) => (
+          <NotificationItem
+            key={noti.id}
+            type={noti.type}
+            username={noti.username}
+            createdAt={noti.createdAt}
+            comment={noti.comment}
+            thumbnailUrl={noti.thumbnailImage}
+          />
+        ))}
       </div>
     </div>
   );

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -49,11 +49,11 @@ const NotificationModal = () => {
   ];
 
   return (
-    <div className="w-[420px] h-[360px] bg-white z-50 border-t border-gray-100 rounded-xl shadow-md p-2">
+    <div className="w-[420px] h-[360px] bg-white z-50 border-t border-gray-100 rounded-xl shadow-md p-1">
       <header>
         <NotificationHeader />
       </header>
-      <div className="h-[310px] overflow-y-auto">
+      <div className="h-[310px] overflow-y-auto pt-3 pb-4">
         {dummyNotifications.map((noti) => (
           <NotificationItem
             key={noti.id}

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -49,7 +49,7 @@ const NotificationModal = () => {
             username={noti.username}
             createdAt={noti.createdAt}
             comment={noti.comment}
-            thumbnailUrl={noti.thumbnailImage}
+            thumbnailImage={noti.thumbnailImage}
           />
         ))}
       </div>

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -37,7 +37,7 @@ const NotificationModal = () => {
   ];
 
   return (
-    <div className="w-[360px] h-[360px] bg-white z-50 border border-gray-200">
+    <div className="w-[360px] h-[360px] bg-white z-50 border-t border-gray-100 rounded-xl shadow-md p-2">
       <header>
         <NotificationHeader />
       </header>

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -6,6 +6,14 @@ import NotificationItem from "./NotificationItem";
 const NotificationModal = () => {
   const dummyNotifications = [
     {
+      id: 5,
+      type: "LIKE" as const,
+      username: "아아",
+      createdAt: "1분 전",
+      //   thumbnailImage: "/images/post/uuid3.png",
+      isRead: true,
+    },
+    {
       id: 4,
       type: "COMMENT" as const,
       username: "냉장고요정",
@@ -45,7 +53,7 @@ const NotificationModal = () => {
       <header>
         <NotificationHeader />
       </header>
-      <div>
+      <div className="h-[310px] overflow-y-auto">
         {dummyNotifications.map((noti) => (
           <NotificationItem
             key={noti.id}

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -4,6 +4,38 @@ import NotificationHeader from "./NotificationHeader";
 import NotificationItem from "./NotificationItem";
 
 const NotificationModal = () => {
+  const dummyNotifications = [
+    {
+      id: 4,
+      type: "COMMENT" as const,
+      username: "냉장고요정",
+      createdAt: "3분 전",
+      comment: "이건 진짜 꿀템이네요!",
+      thumbnailImage: "/images/post/uuid4.png",
+    },
+    {
+      id: 3,
+      type: "LIKE" as const,
+      username: "자취왕",
+      createdAt: "7분 전",
+      thumbnailImage: "/images/post/uuid3.png",
+    },
+    {
+      id: 2,
+      type: "FOLLOW" as const,
+      username: "맛잘알",
+      createdAt: "15분 전",
+    },
+    {
+      id: 1,
+      type: "COMMENT" as const,
+      username: "혼밥천재",
+      createdAt: "30분 전",
+      comment: "레시피 공유 가능할까요?",
+      thumbnailImage: "/images/post/uuid1.png",
+    },
+  ];
+
   return (
     <div className="w-[360px] h-[360px] bg-white z-50 border border-gray-200">
       <header>
@@ -11,7 +43,7 @@ const NotificationModal = () => {
       </header>
       <div>
         {/* map으로 돌려야함 */}
-        <NotificationItem type="LIKE" />
+        <NotificationItem type="COMMENT" />
       </div>
     </div>
   );

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -5,7 +5,7 @@ import NotificationItem from "./NotificationItem";
 
 const NotificationModal = () => {
   return (
-    <div>
+    <div className="w-[360px] h-[360px] bg-white z-50 border border-gray-200">
       <header>
         <NotificationHeader />
       </header>


### PR DESCRIPTION
## 📌 작업 개요
- 알림모달 컴포넌트 ui
- 헤더 알림버튼 누를 시 토글


## ✨ 주요 변경 사항
- 헤더에 알림버튼 누를 시 알림모달 열고 닫음 추가 (useEffect)
- 알림모달 컴포넌트 & 내부 컨포넌트 1. 알림이벤트컴포넌트, 2. 알림헤더컴포넌트 UI
- 더미데이터 사용
- 데이터의 type에 따라 알림이벤트 ui 다르게 렌더링


## 🖼️ 스크린샷 (선택)
> ![image](https://github.com/user-attachments/assets/2a4bdcf8-c95f-4dd1-9b03-ee11917f8c11)
 - figma 디자인

> ![May-30-2025 10-49-40](https://github.com/user-attachments/assets/daab8116-2914-4fb6-9993-90f2e43784ef)
 - 헤더에 연결 -> 헤더 있는 모든 페이지에서 알림모달 여닫음 가능
 - 스크롤바 구현
> 
![그뭐냐](https://github.com/user-attachments/assets/090f3350-10b9-4be0-a3ec-6f69b107d0bf)
- 사이즈 / 미디어쿼리 참고 



## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [ ] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
- localhost 에서 UI 제작 (더미데이터 사용)

## 💬 기타 참고 사항
- 더 구현할 부분
  - 모달 외부 클릭 시 모달 닫힘
  - 알림아이템 호버링 추가
  - username을 눌렀을 때, 상대방 프로필페이지 이동
  - 알림 눌렀을 때 알림 읽음 처리 & 해당 페이지 이동
  - 전체적 CSS (font 스타일링)
  - createdAt은 localDateTime으로 전달할 예정이므로, 날짜 format 변경
  - 등등 ..