### PR TITLE
Feat/notification api : 알림목록조회, 개별알림읽기, 전체알림읽기 api 연결

### DIFF
--- a/src/components/notification/NotificationHeader.tsx
+++ b/src/components/notification/NotificationHeader.tsx
@@ -1,10 +1,23 @@
 "use client";
 
+import { markAllNotificationsAsRead } from "@/lib/api/notification";
+
 const NotificationHeader = () => {
+  const handleMarkAllRead = async () => {
+    try {
+      await markAllNotificationsAsRead();
+    } catch (err) {
+      console.error("전체 읽음 처리 실패", err);
+    }
+  };
+
   return (
     <div className="flex items-center justify-between h-[50px] px-4 py-2 border-b border-gray-200">
       <span className="text-base ml-1 pt-2">알림</span>
-      <button className="text-sm font-semibold text-gray-400 hover:text-gray-600 pt-2 mr-1">
+      <button
+        className="text-sm font-semibold text-gray-400 hover:text-gray-600 pt-2 mr-1"
+        onClick={handleMarkAllRead}
+      >
         전체 읽기
       </button>
     </div>

--- a/src/components/notification/NotificationHeader.tsx
+++ b/src/components/notification/NotificationHeader.tsx
@@ -1,22 +1,16 @@
 "use client";
 
-import { markAllNotificationsAsRead } from "@/lib/api/notification";
+interface NotificationHeaderProps {
+  onMarkAllRead: () => void;
+}
 
-const NotificationHeader = () => {
-  const handleMarkAllRead = async () => {
-    try {
-      await markAllNotificationsAsRead();
-    } catch (err) {
-      console.error("전체 읽음 처리 실패", err);
-    }
-  };
-
+const NotificationHeader = ({ onMarkAllRead }: NotificationHeaderProps) => {
   return (
     <div className="flex items-center justify-between h-[50px] px-4 py-2 border-b border-gray-200">
       <span className="text-base ml-1 pt-2">알림</span>
       <button
         className="text-sm font-semibold text-gray-400 hover:text-gray-600 pt-2 mr-1"
-        onClick={handleMarkAllRead}
+        onClick={onMarkAllRead}
       >
         전체 읽기
       </button>

--- a/src/components/notification/NotificationHeader.tsx
+++ b/src/components/notification/NotificationHeader.tsx
@@ -9,7 +9,7 @@ const NotificationHeader = ({ onMarkAllRead }: NotificationHeaderProps) => {
     <div className="flex items-center justify-between h-[50px] px-4 py-2 border-b border-gray-200">
       <span className="text-base ml-1 pt-2">알림</span>
       <button
-        className="text-sm font-semibold text-gray-400 hover:text-gray-600 pt-2 mr-1"
+        className="text-sm font-semibold text-gray-400 hover:text-gray-400/80 pt-2 mr-1"
         onClick={onMarkAllRead}
       >
         전체 읽기

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import type { NotificationType } from "@/types/notification";
+import type { Notification } from "@/types/notification";
 import { CATEGORY_MAP } from "@/constants/category";
 import { getRelativeTimeAgo } from "@/utils/date";
 import Image from "next/image";
@@ -12,35 +12,26 @@ import { markNotificationAsRead } from "@/lib/api/notification";
 export type MainCategory = keyof typeof CATEGORY_MAP;
 
 type NotificationItemProps = {
-  id: number;
-  type: NotificationType;
-  createdAt: string;
-  actorName: string;
-  actorId: number;
-  actorProfileImage: string | null;
-  postId?: number | null;
-  category?: MainCategory | null;
-  thumbnailImage: string | null;
-  comment?: string | null;
-  isRead: boolean;
+  notification: Notification;
   onClose: () => void;
 };
 
-const NotificationItem = ({
-  id,
-  type,
-  createdAt,
-  actorName,
-  actorId,
-  actorProfileImage,
-  postId,
-  category,
-  thumbnailImage,
-  comment,
-  isRead,
-  onClose,
-}: NotificationItemProps) => {
+const NotificationItem = ({ notification, onClose }: NotificationItemProps) => {
   const router = useRouter();
+
+  const {
+    id,
+    type,
+    createdAt,
+    actorName,
+    actorId,
+    actorProfileImage,
+    postId,
+    category,
+    thumbnailImage,
+    comment,
+    read,
+  } = notification;
 
   const href =
     type === "FOLLOW"
@@ -50,7 +41,7 @@ const NotificationItem = ({
         : undefined;
 
   const handleClick = async () => {
-    if (!isRead) {
+    if (!read) {
       try {
         await markNotificationAsRead(id);
       } catch (err) {
@@ -74,7 +65,7 @@ const NotificationItem = ({
         {/* 읽음 표시 */}
         <span
           className={
-            isRead
+            read
               ? "invisible w-1 h-1"
               : "inline-block w-1 h-1 rounded-full bg-purple-500"
           }

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -6,7 +6,7 @@ import { CATEGORY_MAP } from "@/constants/category";
 import { getRelativeTimeAgo } from "@/utils/date";
 import Image from "next/image";
 import Link from "next/link";
-import { getProfileImageUrl } from "@/utils/image";
+import { getProfileImageUrl, getImageUrl } from "@/utils/image";
 import { markNotificationAsRead } from "@/lib/api/notification";
 
 export type MainCategory = keyof typeof CATEGORY_MAP;
@@ -20,7 +20,7 @@ type NotificationItemProps = {
   actorProfileImage: string | null;
   postId?: number | null;
   category?: MainCategory | null;
-  thumbnailImage?: string | null;
+  thumbnailImage: string | null;
   comment?: string | null;
   isRead: boolean;
   onClose: () => void;
@@ -117,7 +117,9 @@ const NotificationItem = ({
             )}
             {type === "COMMENT" && (
               <>
-                <span className="text-gray-700">님이 댓글을 남겼습니다. :</span>
+                <span className="text-gray-700">
+                  님이 댓글을 남겼습니다. :{" "}
+                </span>
                 <span className="text-gray-700">{comment}</span>
               </>
             )}
@@ -129,7 +131,7 @@ const NotificationItem = ({
           {/* 게시물 썸네일 img (게시물 좋아요일때만) */}
           {type === "LIKE" && (
             <Image
-              src={thumbnailImage || "/icons/placeholderImage.svg"}
+              src={getImageUrl(thumbnailImage) || "/icons/placeholderImage.svg"}
               alt="썸네일 이미지"
               width={56}
               height={56}

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -72,10 +72,7 @@ const NotificationItem = ({ notification, onClose }: NotificationItemProps) => {
         />
         <Link href={`/profile/${actorId}`}>
           <Image
-            src={
-              getProfileImageUrl(actorProfileImage) ||
-              "/icons/defaultProfile.svg"
-            }
+            src={getProfileImageUrl(actorProfileImage)}
             alt="프로필이미지"
             width={40}
             height={40}
@@ -122,7 +119,7 @@ const NotificationItem = ({ notification, onClose }: NotificationItemProps) => {
           {/* 게시물 썸네일 img (게시물 좋아요일때만) */}
           {type === "LIKE" && (
             <Image
-              src={getImageUrl(thumbnailImage) || "/icons/placeholderImage.svg"}
+              src={getImageUrl(thumbnailImage)}
               alt="썸네일 이미지"
               width={56}
               height={56}

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -107,22 +107,17 @@ const NotificationItem = ({
             </Link>
             {type === "LIKE" && (
               <span className="text-gray-700">
-                {" "}
                 님이 회원님의 게시글을 좋아합니다.
               </span>
             )}
             {type === "FOLLOW" && (
               <span className="text-gray-700">
-                {" "}
                 님이 회원님을 팔로우하기 시작했습니다.
               </span>
             )}
             {type === "COMMENT" && (
               <>
-                <span className="text-gray-700">
-                  {" "}
-                  님이 댓글을 남겼습니다. :{" "}
-                </span>
+                <span className="text-gray-700">님이 댓글을 남겼습니다. :</span>
                 <span className="text-gray-700">{comment}</span>
               </>
             )}

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -7,10 +7,12 @@ import { getRelativeTimeAgo } from "@/utils/date";
 import Image from "next/image";
 import Link from "next/link";
 import { getProfileImageUrl } from "@/utils/image";
+import { markNotificationAsRead } from "@/lib/api/notification";
 
 export type MainCategory = keyof typeof CATEGORY_MAP;
 
 type NotificationItemProps = {
+  id: number;
   type: NotificationType;
   createdAt: string;
   actorName: string;
@@ -25,6 +27,7 @@ type NotificationItemProps = {
 };
 
 const NotificationItem = ({
+  id,
   type,
   createdAt,
   actorName,
@@ -46,7 +49,15 @@ const NotificationItem = ({
         ? `/board/${category}/${postId}`
         : undefined;
 
-  const handleClick = () => {
+  const handleClick = async () => {
+    if (!isRead) {
+      try {
+        await markNotificationAsRead(id);
+      } catch (err) {
+        console.error("알림 읽음 처리 실패", err);
+      }
+    }
+
     if (href) {
       router.push(href);
       onClose();

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -13,9 +13,9 @@ export type MainCategory = keyof typeof CATEGORY_MAP;
 type NotificationItemProps = {
   type: NotificationType;
   createdAt: string;
-  username: string;
-  userId: number;
-  profileImage: string | null;
+  actorName: string;
+  actorId: number;
+  actorProfileImage: string | null;
   postId?: number | null;
   category?: MainCategory | null;
   thumbnailImage?: string | null;
@@ -27,9 +27,9 @@ type NotificationItemProps = {
 const NotificationItem = ({
   type,
   createdAt,
-  username,
-  userId,
-  profileImage,
+  actorName,
+  actorId,
+  actorProfileImage,
   postId,
   category,
   thumbnailImage,
@@ -41,7 +41,7 @@ const NotificationItem = ({
 
   const href =
     type === "FOLLOW"
-      ? `/profile/${userId}`
+      ? `/profile/${actorId}`
       : type === "LIKE" || type === "COMMENT"
         ? `/board/${category}/${postId}`
         : undefined;
@@ -68,10 +68,11 @@ const NotificationItem = ({
               : "inline-block w-1 h-1 rounded-full bg-purple-500"
           }
         />
-        <Link href={`/profile/${userId}`}>
+        <Link href={`/profile/${actorId}`}>
           <Image
             src={
-              getProfileImageUrl(profileImage) || "/icons/defaultProfile.svg"
+              getProfileImageUrl(actorProfileImage) ||
+              "/icons/defaultProfile.svg"
             }
             alt="프로필이미지"
             width={40}
@@ -87,11 +88,11 @@ const NotificationItem = ({
         <div className="flex items-center ml-2 mr-2">
           <div>
             <Link
-              href={`/profile/${userId}`}
+              href={`/profile/${actorId}`}
               className="font-semibold text-gray-600 hover:font-bold"
               onClick={(e) => e.stopPropagation()} // 클릭 전파 방지
             >
-              {username}
+              {actorName}
             </Link>
             {type === "LIKE" && (
               <span className="text-gray-700">

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -12,29 +12,29 @@ export type MainCategory = keyof typeof CATEGORY_MAP;
 
 type NotificationItemProps = {
   type: NotificationType;
+  createdAt: string;
   username: string;
   userId: number;
   profileImage: string | null;
-  createdAt: string;
-  comment?: string;
-  thumbnailImage?: string;
+  postId?: number | null;
+  category?: MainCategory | null;
+  thumbnailImage?: string | null;
+  comment?: string | null;
   isRead: boolean;
-  category?: MainCategory;
-  postId?: number;
   onClose: () => void;
 };
 
 const NotificationItem = ({
   type,
+  createdAt,
   username,
   userId,
   profileImage,
-  createdAt,
-  comment,
-  thumbnailImage,
-  isRead,
-  category,
   postId,
+  category,
+  thumbnailImage,
+  comment,
+  isRead,
   onClose,
 }: NotificationItemProps) => {
   const router = useRouter();

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -44,6 +44,7 @@ const NotificationModal = ({ onClose }: NotificationModalProps) => {
         {notifications.map((noti) => (
           <NotificationItem
             key={noti.id}
+            id={noti.id}
             type={noti.type}
             actorName={noti.actorName}
             actorId={noti.actorId}

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -39,9 +39,9 @@ const NotificationModal = ({ onClose }: NotificationModalProps) => {
           <NotificationItem
             key={noti.id}
             type={noti.type}
-            username={noti.username}
-            userId={noti.userId}
-            profileImage={noti.profileImage}
+            actorName={noti.actorName}
+            actorId={noti.actorId}
+            actorProfileImage={noti.actorProfileImage}
             createdAt={noti.createdAt}
             comment={noti.comment}
             thumbnailImage={noti.thumbnailImage}

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -6,6 +6,7 @@ import NotificationItem from "./NotificationItem";
 import { fetchNotifications } from "@/lib/api/notification";
 import type { Notification } from "@/types/notification";
 import { CATEGORY_MAP } from "@/constants/category";
+import { useAuthStore } from "@/stores/useAuthStore";
 
 export type MainCategory = keyof typeof CATEGORY_MAP;
 
@@ -14,9 +15,14 @@ interface NotificationModalProps {
 }
 
 const NotificationModal = ({ onClose }: NotificationModalProps) => {
+  const { user } = useAuthStore();
+  const userId = user?.userId ?? null;
+
   const [notifications, setNotifications] = useState<Notification[]>([]);
 
   useEffect(() => {
+    if (!userId) return;
+
     const fetchData = async () => {
       try {
         const data = await fetchNotifications();
@@ -27,7 +33,7 @@ const NotificationModal = ({ onClose }: NotificationModalProps) => {
     };
 
     fetchData();
-  }, []);
+  }, [userId]);
 
   return (
     <div className="w-[420px] h-[360px] bg-white z-50 border-t border-gray-100 rounded-xl shadow-md p-1 overflow-hidden">

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -3,7 +3,10 @@
 import { useEffect, useState } from "react";
 import NotificationHeader from "./NotificationHeader";
 import NotificationItem from "./NotificationItem";
-import { fetchNotifications } from "@/lib/api/notification";
+import {
+  fetchNotifications,
+  markAllNotificationsAsRead,
+} from "@/lib/api/notification";
 import type { Notification } from "@/types/notification";
 import { CATEGORY_MAP } from "@/constants/category";
 import { useAuthStore } from "@/stores/useAuthStore";
@@ -35,10 +38,20 @@ const NotificationModal = ({ onClose }: NotificationModalProps) => {
     fetchData();
   }, [userId]);
 
+  const handleMarkAllRead = async () => {
+    try {
+      await markAllNotificationsAsRead();
+      const updated = await fetchNotifications();
+      setNotifications(updated);
+    } catch (err) {
+      console.error("전체 읽음 처리 실패", err);
+    }
+  };
+
   return (
     <div className="w-[420px] h-[360px] bg-white z-50 border-t border-gray-100 rounded-xl shadow-md p-1 overflow-hidden">
       <header>
-        <NotificationHeader />
+        <NotificationHeader onMarkAllRead={handleMarkAllRead} />
       </header>
       <ul className="h-[310px] overflow-y-auto pt-1 pb-3">
         {notifications.map((noti) => (

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -28,67 +28,6 @@ const NotificationModal = ({ onClose }: NotificationModalProps) => {
 
     fetchData();
   }, []);
-  // const dummyNotifications = [
-  //   {
-  //     id: 5,
-  //     type: "LIKE" as const,
-  //     username: "아아",
-  //     userId: 23,
-  //     profileImage: null,
-  //     createdAt: "2025-05-30T12:34:56",
-  //     //   thumbnailImage: "/images/post/uuid3.png",
-  //     isRead: true,
-  //     category: "TOGETHER" as MainCategory,
-  //     postId: 2,
-  //   },
-  //   {
-  //     id: 4,
-  //     type: "COMMENT" as const,
-  //     username: "냉장고요정",
-  //     userId: 12,
-  //     profileImage: null,
-  //     createdAt: "2025-05-28T12:34:56",
-  //     comment: "이건 진짜 꿀템이네요!",
-  //     thumbnailImage: "/images/post/uuid4.png",
-  //     isRead: false,
-  //     category: "TOGETHER" as MainCategory,
-  //     postId: 2,
-  //   },
-  //   {
-  //     id: 3,
-  //     type: "LIKE" as const,
-  //     username: "자취왕",
-  //     userId: 9,
-  //     profileImage: null,
-  //     createdAt: "2025-05-21T12:34:56",
-  //     //   thumbnailImage: "/images/post/uuid3.png",
-  //     isRead: true,
-  //     category: "DAILY_LIFE" as MainCategory,
-  //     postId: 5,
-  //   },
-  //   {
-  //     id: 2,
-  //     type: "FOLLOW" as const,
-  //     username: "맛잘알",
-  //     userId: 5,
-  //     profileImage: null,
-  //     createdAt: "2025-05-21T12:34:56",
-  //     isRead: true,
-  //   },
-  //   {
-  //     id: 1,
-  //     type: "COMMENT" as const,
-  //     username: "혼밥천재",
-  //     userId: 88,
-  //     profileImage: null,
-  //     createdAt: "2025-05-21T12:34:56",
-  //     comment: "레시피 공유 가능할까요?",
-  //     thumbnailImage: "2025-05-21T12:34:56",
-  //     isRead: false,
-  //     category: "RANDOM_BUY" as MainCategory,
-  //     postId: 8,
-  //   },
-  // ];
 
   return (
     <div className="w-[420px] h-[360px] bg-white z-50 border-t border-gray-100 rounded-xl shadow-md p-1 overflow-hidden">

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import NotificationHeader from "./NotificationHeader";
 import NotificationItem from "./NotificationItem";
+import { fetchNotifications } from "@/lib/api/notification";
+import type { Notification } from "@/types/notification";
 import { CATEGORY_MAP } from "@/constants/category";
 
 export type MainCategory = keyof typeof CATEGORY_MAP;
@@ -11,67 +14,81 @@ interface NotificationModalProps {
 }
 
 const NotificationModal = ({ onClose }: NotificationModalProps) => {
-  const dummyNotifications = [
-    {
-      id: 5,
-      type: "LIKE" as const,
-      username: "아아",
-      userId: 23,
-      profileImage: null,
-      createdAt: "2025-05-30T12:34:56",
-      //   thumbnailImage: "/images/post/uuid3.png",
-      isRead: true,
-      category: "TOGETHER" as MainCategory,
-      postId: 2,
-    },
-    {
-      id: 4,
-      type: "COMMENT" as const,
-      username: "냉장고요정",
-      userId: 12,
-      profileImage: null,
-      createdAt: "2025-05-28T12:34:56",
-      comment: "이건 진짜 꿀템이네요!",
-      thumbnailImage: "/images/post/uuid4.png",
-      isRead: false,
-      category: "TOGETHER" as MainCategory,
-      postId: 2,
-    },
-    {
-      id: 3,
-      type: "LIKE" as const,
-      username: "자취왕",
-      userId: 9,
-      profileImage: null,
-      createdAt: "2025-05-21T12:34:56",
-      //   thumbnailImage: "/images/post/uuid3.png",
-      isRead: true,
-      category: "DAILY_LIFE" as MainCategory,
-      postId: 5,
-    },
-    {
-      id: 2,
-      type: "FOLLOW" as const,
-      username: "맛잘알",
-      userId: 5,
-      profileImage: null,
-      createdAt: "2025-05-21T12:34:56",
-      isRead: true,
-    },
-    {
-      id: 1,
-      type: "COMMENT" as const,
-      username: "혼밥천재",
-      userId: 88,
-      profileImage: null,
-      createdAt: "2025-05-21T12:34:56",
-      comment: "레시피 공유 가능할까요?",
-      thumbnailImage: "2025-05-21T12:34:56",
-      isRead: false,
-      category: "RANDOM_BUY" as MainCategory,
-      postId: 8,
-    },
-  ];
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await fetchNotifications();
+        setNotifications(data);
+      } catch (e) {
+        console.error("알림 목록 불러오기 실패", e);
+      }
+    };
+
+    fetchData();
+  }, []);
+  // const dummyNotifications = [
+  //   {
+  //     id: 5,
+  //     type: "LIKE" as const,
+  //     username: "아아",
+  //     userId: 23,
+  //     profileImage: null,
+  //     createdAt: "2025-05-30T12:34:56",
+  //     //   thumbnailImage: "/images/post/uuid3.png",
+  //     isRead: true,
+  //     category: "TOGETHER" as MainCategory,
+  //     postId: 2,
+  //   },
+  //   {
+  //     id: 4,
+  //     type: "COMMENT" as const,
+  //     username: "냉장고요정",
+  //     userId: 12,
+  //     profileImage: null,
+  //     createdAt: "2025-05-28T12:34:56",
+  //     comment: "이건 진짜 꿀템이네요!",
+  //     thumbnailImage: "/images/post/uuid4.png",
+  //     isRead: false,
+  //     category: "TOGETHER" as MainCategory,
+  //     postId: 2,
+  //   },
+  //   {
+  //     id: 3,
+  //     type: "LIKE" as const,
+  //     username: "자취왕",
+  //     userId: 9,
+  //     profileImage: null,
+  //     createdAt: "2025-05-21T12:34:56",
+  //     //   thumbnailImage: "/images/post/uuid3.png",
+  //     isRead: true,
+  //     category: "DAILY_LIFE" as MainCategory,
+  //     postId: 5,
+  //   },
+  //   {
+  //     id: 2,
+  //     type: "FOLLOW" as const,
+  //     username: "맛잘알",
+  //     userId: 5,
+  //     profileImage: null,
+  //     createdAt: "2025-05-21T12:34:56",
+  //     isRead: true,
+  //   },
+  //   {
+  //     id: 1,
+  //     type: "COMMENT" as const,
+  //     username: "혼밥천재",
+  //     userId: 88,
+  //     profileImage: null,
+  //     createdAt: "2025-05-21T12:34:56",
+  //     comment: "레시피 공유 가능할까요?",
+  //     thumbnailImage: "2025-05-21T12:34:56",
+  //     isRead: false,
+  //     category: "RANDOM_BUY" as MainCategory,
+  //     postId: 8,
+  //   },
+  // ];
 
   return (
     <div className="w-[420px] h-[360px] bg-white z-50 border-t border-gray-100 rounded-xl shadow-md p-1 overflow-hidden">
@@ -79,7 +96,7 @@ const NotificationModal = ({ onClose }: NotificationModalProps) => {
         <NotificationHeader />
       </header>
       <ul className="h-[310px] overflow-y-auto pt-1 pb-3">
-        {dummyNotifications.map((noti) => (
+        {notifications.map((noti) => (
           <NotificationItem
             key={noti.id}
             type={noti.type}
@@ -89,7 +106,7 @@ const NotificationModal = ({ onClose }: NotificationModalProps) => {
             createdAt={noti.createdAt}
             comment={noti.comment}
             thumbnailImage={noti.thumbnailImage}
-            isRead={noti.isRead}
+            isRead={noti.read}
             category={noti.category}
             postId={noti.postId}
             onClose={onClose}

--- a/src/components/notification/NotificationModal.tsx
+++ b/src/components/notification/NotificationModal.tsx
@@ -57,17 +57,7 @@ const NotificationModal = ({ onClose }: NotificationModalProps) => {
         {notifications.map((noti) => (
           <NotificationItem
             key={noti.id}
-            id={noti.id}
-            type={noti.type}
-            actorName={noti.actorName}
-            actorId={noti.actorId}
-            actorProfileImage={noti.actorProfileImage}
-            createdAt={noti.createdAt}
-            comment={noti.comment}
-            thumbnailImage={noti.thumbnailImage}
-            isRead={noti.read}
-            category={noti.category}
-            postId={noti.postId}
+            notification={noti}
             onClose={onClose}
           />
         ))}

--- a/src/lib/api/notification.ts
+++ b/src/lib/api/notification.ts
@@ -1,0 +1,8 @@
+import { client } from "@/lib/fetch/client";
+import { NotificationItem } from "@/types/notification";
+
+export const fetchNotifications = async (): Promise<NotificationItem[]> => {
+  return await client<NotificationItem[]>("/notifications", {
+    method: "GET",
+  });
+};

--- a/src/lib/api/notification.ts
+++ b/src/lib/api/notification.ts
@@ -12,3 +12,9 @@ export const markNotificationAsRead = async (notificationId: number) => {
     method: "PATCH",
   });
 };
+
+export const markAllNotificationsAsRead = async () => {
+  return await client("/notifications/bulk", {
+    method: "PATCH",
+  });
+};

--- a/src/lib/api/notification.ts
+++ b/src/lib/api/notification.ts
@@ -1,8 +1,8 @@
 import { client } from "@/lib/fetch/client";
-import { NotificationItem } from "@/types/notification";
+import { Notification } from "@/types/notification";
 
-export const fetchNotifications = async (): Promise<NotificationItem[]> => {
-  return await client<NotificationItem[]>("/notifications", {
+export const fetchNotifications = async (): Promise<Notification[]> => {
+  return await client<Notification[]>("/notifications", {
     method: "GET",
   });
 };

--- a/src/lib/api/notification.ts
+++ b/src/lib/api/notification.ts
@@ -6,3 +6,9 @@ export const fetchNotifications = async (): Promise<Notification[]> => {
     method: "GET",
   });
 };
+
+export const markNotificationAsRead = async (notificationId: number) => {
+  await client(`/notifications/${notificationId}`, {
+    method: "PATCH",
+  });
+};

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,1 +1,15 @@
 export type NotificationType = "LIKE" | "FOLLOW" | "COMMENT";
+
+export interface NotificationItem {
+  id: number;
+  type: NotificationType;
+  targetId: number;
+  createdAt: string;
+  userId: number;
+  username: string;
+  profileImage: string | null;
+  category: string | null;
+  thumbnailImage: string | null;
+  comment: string | null;
+  read: boolean;
+}

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,6 +1,8 @@
+import type { MainCategory } from "@/components/notification/NotificationModal";
+
 export type NotificationType = "LIKE" | "FOLLOW" | "COMMENT";
 
-export interface NotificationItem {
+export interface Notification {
   id: number;
   type: NotificationType;
   targetId: number;
@@ -8,7 +10,8 @@ export interface NotificationItem {
   userId: number;
   username: string;
   profileImage: string | null;
-  category: string | null;
+  postId: number | null;
+  category: MainCategory | null;
   thumbnailImage: string | null;
   comment: string | null;
   read: boolean;

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -7,9 +7,9 @@ export interface Notification {
   type: NotificationType;
   targetId: number;
   createdAt: string;
-  userId: number;
-  username: string;
-  profileImage: string | null;
+  actorId: number;
+  actorName: string;
+  actorProfileImage: string | null;
   postId: number | null;
   category: MainCategory | null;
   thumbnailImage: string | null;


### PR DESCRIPTION
## 📌 작업 개요
- 알림목록조회 api 연결
- 개별알림읽기 api 연결
- 전체알림읽기 api 연결
- 리뷰 반영 : 공백 표시 교체
  - #61 
- 썸네일 이미지에도 url 변환 유틸메서드 붙임

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 알림 유발 유저(?) 명칭 user -> actor로 교체 (BE 응답포맷도 같이 교체했습니다)
- 더미데이터 삭제하고 api 연결로 대체

## 🖼️ 스크린샷 (선택)
> <img width="701" alt="스크린샷 2025-06-02 오후 4 56 55" src="https://github.com/user-attachments/assets/d8130086-2f7c-4048-8a8c-b3da05273d2d" />
> **알림목록조회 api 연결 (DB 반영, 최신순)**

> ![개별읽음](https://github.com/user-attachments/assets/8cff25fa-0716-4b80-bbb3-6898b424f000)
  **개별 읽기 api 연결**
  - 알림 아이템 클릭 시 기본적으로 해당 게시물/유저프로필 이동 & 알림 모달 닫힘
  - 안읽은 알림 아이템 클릭 시 읽음 처리 추가 ('안읽음표시 == 보라색 점' 사라짐)
  - api호출로 읽음처리 DB에 반영

> ![전체읽기](https://github.com/user-attachments/assets/b1b7dcef-0554-411e-9b69-1b442399bb41)
  전체 읽기 api 연결
  - 전체읽기 버튼 클릭 시, 안읽은 알림들 마저 읽음처리 (보라색 점 사라짐)
  - 재렌더링으로 UI 즉시 반영 (알림조회 호출)
  - api호출로 전체읽음처리 DB에 반영
 
## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [ ] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
- localhost:3000
- DBvear로 DB 조회

## 💬 기타 참고 사항
- 🤔 ❓ : 알림 전체 읽기의 경우, 새로고침없이 보라색점들을 없애기 위해서
  1. ui에서 따로 보라색점을 없어지게 하는 방법 (fetch 정상 성공시에만 작동, 상태는 props로 내려줘야함)
  2. 목록조회api 호출하여 재렌더링으로 DB와 동일한 상태를 유지하는 방법
  
  이 두가지 중 2번째 방법을 택했습니다
  (ui에서만 보라점이 사라지고, db에서는 처리가 제대로 안 되었을 때는 유저에게 잘못된 정보를 줄 수 있다고 생각했기 때문)

  api호출을 늘리는 것이 좋진 않기에, 어떤 선택이 더 나은지, 또는 더 좋은 선택지가 있었는지 궁금합니다...!