### PR TITLE
즐겨찾기 그룹 API 추가와 즐겨찾기 상세 UI 와 API 추가

### DIFF
--- a/src/app/favorite/[groupId]/FavoritePageClient.tsx
+++ b/src/app/favorite/[groupId]/FavoritePageClient.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useFavoriteItems } from "@/hooks/useFavoriteItems";
+import FavoriteItemCard from "@/components/Profile/FavoriteItemCard";
+
+export default function FavoritePage({ groupId }: { groupId: number }) {
+  const { data: items, isLoading, error } = useFavoriteItems(groupId);
+
+  if (isLoading) return <div>로딩 중...</div>;
+  if (error) return <div>에러가 발생했습니다: {(error as Error).message}</div>;
+  if (!items || items.length === 0) return <div>즐겨찾기 항목이 없습니다.</div>;
+
+  return (
+    <div className="max-w-3xl mx-auto py-6">
+      <h2 className="text-xl font-bold mb-4">즐겨찾기 그룹 상세</h2>
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li key={item.id}>
+            <FavoriteItemCard item={item} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/favorite/[groupId]/FavoritePageClient.tsx
+++ b/src/app/favorite/[groupId]/FavoritePageClient.tsx
@@ -1,11 +1,34 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useFavoriteItems } from "@/hooks/useFavoriteItems";
 import FavoriteItemCard from "@/components/Profile/FavoriteItemCard";
+import { fetchBookmarkGroups } from "@/lib/api/bookmark";
+import { useAuthStore } from "@/stores/useAuthStore";
 
 export default function FavoritePage({ groupId }: { groupId: number }) {
   const { data: items, isLoading, error } = useFavoriteItems(groupId);
+  const { user } = useAuthStore();
+
   const displayItems = items?.filter((item) => !item.deleted) ?? [];
+  const [groupName, setGroupName] = useState<string>("");
+
+  // 해당 groupId 그룹 이름 가져오기
+  useEffect(() => {
+    const fetchGroupName = async () => {
+      if (!user?.userId) return;
+
+      try {
+        const groups = await fetchBookmarkGroups(user.userId);
+        const matched = groups.find((g) => g.groupId === groupId);
+        setGroupName(matched?.name ?? "(알 수 없음)");
+      } catch {
+        setGroupName("(그룹 이름 로딩 실패)");
+      }
+    };
+
+    fetchGroupName();
+  }, [groupId, user?.userId]);
 
   if (isLoading) return <div>로딩 중...</div>;
   if (error) return <div>에러가 발생했습니다: {(error as Error).message}</div>;
@@ -13,7 +36,7 @@ export default function FavoritePage({ groupId }: { groupId: number }) {
 
   return (
     <div className="max-w-3xl mx-auto py-6">
-      <h2 className="text-xl font-bold mb-4">즐겨찾기 그룹 상세</h2>
+      <h2 className="text-xl font-bold mb-4 text-center">{groupName}</h2>
       <ul className="space-y-2">
         {displayItems.map((item) => (
           <li key={item.id}>

--- a/src/app/favorite/[groupId]/FavoritePageClient.tsx
+++ b/src/app/favorite/[groupId]/FavoritePageClient.tsx
@@ -5,6 +5,7 @@ import FavoriteItemCard from "@/components/Profile/FavoriteItemCard";
 
 export default function FavoritePage({ groupId }: { groupId: number }) {
   const { data: items, isLoading, error } = useFavoriteItems(groupId);
+  const displayItems = items?.filter((item) => !item.deleted) ?? [];
 
   if (isLoading) return <div>로딩 중...</div>;
   if (error) return <div>에러가 발생했습니다: {(error as Error).message}</div>;
@@ -14,7 +15,7 @@ export default function FavoritePage({ groupId }: { groupId: number }) {
     <div className="max-w-3xl mx-auto py-6">
       <h2 className="text-xl font-bold mb-4">즐겨찾기 그룹 상세</h2>
       <ul className="space-y-2">
-        {items.map((item) => (
+        {displayItems.map((item) => (
           <li key={item.id}>
             <FavoriteItemCard item={item} />
           </li>

--- a/src/app/favorite/[groupId]/FavoritePageClient.tsx
+++ b/src/app/favorite/[groupId]/FavoritePageClient.tsx
@@ -36,7 +36,10 @@ export default function FavoritePage({ groupId }: { groupId: number }) {
 
   return (
     <div className="max-w-3xl mx-auto py-6">
-      <h2 className="text-xl font-bold mb-4 text-center">{groupName}</h2>
+      <div className="flex flex-col items-center gap-4 mb-10">
+        <h2 className="text-xl font-bold">{groupName}</h2>
+        <p className="text-gray600">장소 {displayItems.length}</p>
+      </div>
       <ul className="space-y-2">
         {displayItems.map((item) => (
           <li key={item.id}>

--- a/src/app/favorite/[groupId]/page.tsx
+++ b/src/app/favorite/[groupId]/page.tsx
@@ -1,0 +1,5 @@
+import FavoritePageClient from "./FavoritePageClient";
+
+export default function Page({ params }: { params: { groupId: string } }) {
+  return <FavoritePageClient groupId={parseInt(params.groupId)} />;
+}

--- a/src/components/Profile/BookmarkGroupCard.tsx
+++ b/src/components/Profile/BookmarkGroupCard.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import { MoreVerticalIcon } from "lucide-react";
 import type { BookmarkGroupType } from "@/types/bookmark";
+import Link from "next/link";
 import {
   updateBookmarkGroupName,
   deleteBookmarkGroup,
@@ -92,7 +93,12 @@ export default function BookmarkGroupCard({
               className="text-sm font-semibold px-2 py-1 rounded bg-white border border-gray300 focus:outline-none"
             />
           ) : (
-            <span className="font-semibold">{displayName}</span>
+            <Link
+              href={`/favorite/${group.groupId}`}
+              className="font-semibold hover:underline"
+            >
+              {displayName}
+            </Link>
           )}
           <span className="text-sm text-gray600">장소 4</span>
         </div>

--- a/src/components/Profile/BookmarkGroupCard.tsx
+++ b/src/components/Profile/BookmarkGroupCard.tsx
@@ -3,7 +3,10 @@
 import { useState, useRef, useEffect } from "react";
 import { MoreVerticalIcon } from "lucide-react";
 import type { BookmarkGroupType } from "@/types/bookmark";
-import { updateBookmarkGroupName } from "@/lib/api/bookmark";
+import {
+  updateBookmarkGroupName,
+  deleteBookmarkGroup,
+} from "@/lib/api/bookmark";
 
 interface BookmarkGroupProps {
   group: BookmarkGroupType;
@@ -53,6 +56,17 @@ export default function BookmarkGroupCard({
         console.error("수정 실패:", e);
         alert("수정에 실패했습니다.");
       }
+    }
+  };
+
+  // 즐겨찾기 그룹 삭제
+  const handleDelete = async () => {
+    try {
+      await deleteBookmarkGroup(group.groupId);
+      onDelete?.(group.groupId); // 부모에서 상태 업데이트
+    } catch (e) {
+      console.error("삭제 실패:", e);
+      alert("삭제에 실패했습니다.");
     }
   };
 
@@ -111,7 +125,7 @@ export default function BookmarkGroupCard({
             className="w-full px-4 py-2 text-left text-sm text-red-500 hover:bg-gray100 flex items-center gap-2"
             onClick={() => {
               setIsMenuOpen(false);
-              onDelete(group.groupId);
+              handleDelete();
             }}
           >
             삭제

--- a/src/components/Profile/BookmarkGroupCard.tsx
+++ b/src/components/Profile/BookmarkGroupCard.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import { MoreVerticalIcon } from "lucide-react";
 import type { BookmarkGroupType } from "@/types/bookmark";
+import { updateBookmarkGroupName } from "@/lib/api/bookmark";
 
 interface BookmarkGroupProps {
   group: BookmarkGroupType;
@@ -40,15 +41,18 @@ export default function BookmarkGroupCard({
     }
   }, [isEditing]);
 
-  // 수정 완료
-  const handleEditComplete = () => {
+  // 즐겨찾기 그룹 이름 수정
+  const handleEditComplete = async () => {
     if (editedName.trim() !== "") {
-      setDisplayName(editedName); // 화면 갱신
-      setIsEditing(false);
-      setIsMenuOpen(false);
-
-      // TODO: 추후 여기에 PATCH API 연결
-      // await updateBookmarkGroupName(group.groupId, editedName)
+      try {
+        await updateBookmarkGroupName(group.groupId, editedName);
+        setDisplayName(editedName);
+        setIsEditing(false);
+        setIsMenuOpen(false);
+      } catch (e) {
+        console.error("수정 실패:", e);
+        alert("수정에 실패했습니다.");
+      }
     }
   };
 

--- a/src/components/Profile/BookmarkGroupList.tsx
+++ b/src/components/Profile/BookmarkGroupList.tsx
@@ -52,7 +52,7 @@ export default function BookmarkGroupList() {
   };
 
   return (
-      <div className="space-y-2">
+    <div className="space-y-2">
       {/* 그룹 추가 버튼 */}
       <div className="flex justify-end mb-2">
         <button
@@ -63,13 +63,14 @@ export default function BookmarkGroupList() {
         </button>
       </div>
 
-      {groupList.map((group) => (
-        <BookmarkGroupCard
-          key={group.groupId}
-          group={group}
-          onDelete={handleDeleteGroup}
-        />
-      ))}
+      {/* 즐겨찾기 그룹 리스트 */}
+      <ul className="space-y-2">
+        {groupList.map((group) => (
+          <li key={group.groupId}>
+            <BookmarkGroupCard group={group} onDelete={handleDeleteGroup} />
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/components/Profile/BookmarkGroupList.tsx
+++ b/src/components/Profile/BookmarkGroupList.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from "@/stores/useAuthStore";
 import { useBookmarkGroups } from "@/hooks/useBookmarkGroups";
 import { mockBookmarkGroups } from "@/mock/bookmarkGroup.mock";
 import type { BookmarkGroupType } from "@/types/bookmark";
+import { createBookmarkGroup } from "@/lib/api/bookmark";
 
 export default function BookmarkGroupList() {
   const { user } = useAuthStore();
@@ -36,8 +37,32 @@ export default function BookmarkGroupList() {
   if (!groupList || groupList.length === 0)
     return <div>즐겨찾기 그룹이 없습니다.</div>;
 
+  // 즐겨찾기 그룹 추가
+  const handleCreateGroup = async () => {
+    const name = prompt("새 그룹 이름을 입력하세요:");
+    if (!name?.trim()) return;
+
+    try {
+      const newGroup = await createBookmarkGroup(name.trim());
+      setGroupList((prev) => [...prev, newGroup]);
+    } catch (e) {
+      console.error("그룹 생성 실패", e);
+      alert("그룹 생성에 실패했습니다.");
+    }
+  };
+
   return (
-    <div className="space-y-2">
+      <div className="space-y-2">
+      {/* 그룹 추가 버튼 */}
+      <div className="flex justify-end mb-2">
+        <button
+          onClick={handleCreateGroup}
+          className="text-sm text-violet600 underline hover:text-violet800"
+        >
+          그룹 추가
+        </button>
+      </div>
+
       {groupList.map((group) => (
         <BookmarkGroupCard
           key={group.groupId}

--- a/src/components/Profile/FavoriteItemCard.tsx
+++ b/src/components/Profile/FavoriteItemCard.tsx
@@ -1,18 +1,124 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
 import type { FavoriteItemType } from "@/types/favorite";
+import { MoreVerticalIcon } from "lucide-react";
+import { updateFavoriteItem, deleteFavoriteItem } from "@/lib/api/favorite";
 
 interface Props {
   item: FavoriteItemType;
+  onDelete?: (itemId: number) => void;
 }
 
-export default function FavoriteItemCard({ item }: Props) {
+export default function FavoriteItemCard({ item, onDelete }: Props) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedMemo, setEditedMemo] = useState(item.memo);
+  const [displayMemo, setDisplayMemo] = useState(item.memo);
+
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // 외부 클릭 시 메뉴 닫기
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // 수정 모드 시 input 포커스
+  useEffect(() => {
+    if (isEditing) inputRef.current?.focus();
+  }, [isEditing]);
+
+  const handleEditComplete = async () => {
+    try {
+      await updateFavoriteItem(item.id, editedMemo);
+      setDisplayMemo(editedMemo);
+      setIsEditing(false);
+    } catch (e) {
+      console.error("메모 수정 실패", e);
+      alert("수정에 실패했습니다.");
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteFavoriteItem(item.id);
+      onDelete?.(item.id); // 부모에서 displayItems 갱신
+    } catch (e) {
+      console.error("삭제 실패", e);
+      alert("삭제에 실패했습니다.");
+    }
+  };
+
   return (
-    <li className="p-4 border rounded-md shadow-sm space-y-1">
-      <div className="font-semibold">
-        장소 이름
-        <span className="font-normal text-gray600 ml-4">{item.address}</span>
+    <li className="p-4 border rounded-md shadow-sm relative">
+      <div className="flex justify-between">
+        <div className="font-semibold">
+          장소 이름
+          <span className="font-normal text-gray600 ml-4">{item.address}</span>
+        </div>
+
+        <button
+          className="text-gray600 hover:text-black"
+          onClick={() => setIsMenuOpen((prev) => !prev)}
+          ref={buttonRef}
+        >
+          <MoreVerticalIcon width={20} height={20} />
+        </button>
+
+        {isMenuOpen && (
+          <div
+            ref={menuRef}
+            className="absolute right-2 top-10 w-24 bg-white rounded-lg shadow-lg z-10"
+          >
+            <button
+              className="w-full px-4 py-2 text-left text-sm hover:bg-gray100"
+              onClick={() => {
+                setIsEditing(true);
+                setIsMenuOpen(false);
+              }}
+            >
+              수정
+            </button>
+            <button
+              className="w-full px-4 py-2 text-left text-sm text-red-500 hover:bg-gray100"
+              onClick={() => {
+                setIsMenuOpen(false);
+                handleDelete();
+              }}
+            >
+              삭제
+            </button>
+          </div>
+        )}
       </div>
-      <p className="text-sm text-gray600">여기는 메모 자리 - {item.memo}</p>
-      <p className="text-xs text-gray600">
+
+      {isEditing ? (
+        <input
+          ref={inputRef}
+          value={editedMemo}
+          onChange={(e) => setEditedMemo(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleEditComplete();
+            if (e.key === "Escape") {
+              setIsEditing(false);
+              setEditedMemo(displayMemo);
+            }
+          }}
+          className="mt-2 text-sm px-2 py-1 rounded border border-gray300 w-full"
+        />
+      ) : (
+        <p className="text-sm text-gray600 mt-2">메모: {displayMemo}</p>
+      )}
+
+      <p className="text-xs text-gray600 mt-1">
         위도: {item.lat}, 경도: {item.lng}
       </p>
     </li>

--- a/src/components/Profile/FavoriteItemCard.tsx
+++ b/src/components/Profile/FavoriteItemCard.tsx
@@ -1,0 +1,17 @@
+import type { FavoriteItemType } from "@/types/favorite";
+
+interface Props {
+  item: FavoriteItemType;
+}
+
+export default function FavoriteItemCard({ item }: Props) {
+  return (
+    <li className="p-4 border rounded-md shadow-sm space-y-1">
+      <p className="font-semibold">{item.address}</p>
+      <p className="text-sm text-gray-500">{item.memo}</p>
+      <p className="text-xs text-gray-400">
+        위도: {item.lat}, 경도: {item.lng}
+      </p>
+    </li>
+  );
+}

--- a/src/components/Profile/FavoriteItemCard.tsx
+++ b/src/components/Profile/FavoriteItemCard.tsx
@@ -7,9 +7,12 @@ interface Props {
 export default function FavoriteItemCard({ item }: Props) {
   return (
     <li className="p-4 border rounded-md shadow-sm space-y-1">
-      <p className="font-semibold">{item.address}</p>
-      <p className="text-sm text-gray-500">{item.memo}</p>
-      <p className="text-xs text-gray-400">
+      <div className="font-semibold">
+        장소 이름
+        <span className="font-normal text-gray600 ml-4">{item.address}</span>
+      </div>
+      <p className="text-sm text-gray600">여기는 메모 자리 - {item.memo}</p>
+      <p className="text-xs text-gray600">
         위도: {item.lat}, 경도: {item.lng}
       </p>
     </li>

--- a/src/components/Profile/FavoriteItemCard.tsx
+++ b/src/components/Profile/FavoriteItemCard.tsx
@@ -85,7 +85,7 @@ export default function FavoriteItemCard({ item, onDelete }: Props) {
                 setIsMenuOpen(false);
               }}
             >
-              수정
+              메모 수정
             </button>
             <button
               className="w-full px-4 py-2 text-left text-sm text-red-500 hover:bg-gray100"

--- a/src/hooks/useBookmarkGroups.ts
+++ b/src/hooks/useBookmarkGroups.ts
@@ -1,14 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { client } from "@/lib/fetch/client";
-import type { BookmarkGroupType } from "@/types/bookmark";
-
-const fetchBookmarkGroups = async (
-  userId: number,
-): Promise<BookmarkGroupType[]> => {
-  return await client<BookmarkGroupType[]>(`/group/user/${userId}/group`, {
-    method: "GET",
-  });
-};
+import { fetchBookmarkGroups } from "@/lib/api/bookmark";
 
 export const useBookmarkGroups = (userId: number | null) => {
   return useQuery({
@@ -17,7 +8,7 @@ export const useBookmarkGroups = (userId: number | null) => {
       if (!userId) throw new Error("userId가 없습니다");
       return fetchBookmarkGroups(userId);
     },
-    enabled: userId !== null,
+    enabled: !!userId,
     staleTime: 1000 * 60 * 5,
   });
 };

--- a/src/hooks/useFavoriteItems.ts
+++ b/src/hooks/useFavoriteItems.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchFavoriteItems } from "@/lib/api/favorite";
+
+export const useFavoriteItems = (groupId: number | null) => {
+  return useQuery({
+    queryKey: ["favoriteItems", groupId],
+    queryFn: () => {
+      if (!groupId) throw new Error("그룹 ID 없음");
+      return fetchFavoriteItems(groupId);
+    },
+    enabled: !!groupId, // groupId 있을 때만 실행
+    staleTime: 1000 * 60 * 5,
+  });
+};

--- a/src/lib/api/bookmark.ts
+++ b/src/lib/api/bookmark.ts
@@ -1,4 +1,14 @@
 import { client } from "@/lib/fetch/client";
+import type { BookmarkGroupType } from "@/types/bookmark";
+
+// 즐겨찾기 그룹 목록 조회
+export const fetchBookmarkGroups = async (
+  userId: number,
+): Promise<BookmarkGroupType[]> => {
+  return await client<BookmarkGroupType[]>(`/group/user/${userId}/group`, {
+    method: "GET",
+  });
+};
 
 // 즐겨찾기 그룹 이름 수정
 export const updateBookmarkGroupName = async (
@@ -11,7 +21,7 @@ export const updateBookmarkGroupName = async (
   });
 };
 
-// 그룹 삭제
+// 즐겨찾기 그룹 삭제
 export const deleteBookmarkGroup = async (groupId: number): Promise<void> => {
   return await client(`/group/${groupId}`, {
     method: "DELETE",

--- a/src/lib/api/bookmark.ts
+++ b/src/lib/api/bookmark.ts
@@ -10,3 +10,10 @@ export const updateBookmarkGroupName = async (
     body: JSON.stringify({ groupName }),
   });
 };
+
+// 그룹 삭제
+export const deleteBookmarkGroup = async (groupId: number): Promise<void> => {
+  return await client(`/group/${groupId}`, {
+    method: "DELETE",
+  });
+};

--- a/src/lib/api/bookmark.ts
+++ b/src/lib/api/bookmark.ts
@@ -1,6 +1,16 @@
 import { client } from "@/lib/fetch/client";
 import type { BookmarkGroupType } from "@/types/bookmark";
 
+// 즐겨찾기 그룹 추가
+export const createBookmarkGroup = async (
+  groupName: string,
+): Promise<BookmarkGroupType> => {
+  return await client<BookmarkGroupType>("/group", {
+    method: "POST",
+    body: JSON.stringify({ groupName }),
+  });
+};
+
 // 즐겨찾기 그룹 목록 조회
 export const fetchBookmarkGroups = async (
   userId: number,

--- a/src/lib/api/bookmark.ts
+++ b/src/lib/api/bookmark.ts
@@ -1,0 +1,12 @@
+import { client } from "@/lib/fetch/client";
+
+// 즐겨찾기 그룹 이름 수정
+export const updateBookmarkGroupName = async (
+  groupId: number,
+  groupName: string,
+): Promise<void> => {
+  return await client(`/group/${groupId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ groupName }),
+  });
+};

--- a/src/lib/api/favorite.ts
+++ b/src/lib/api/favorite.ts
@@ -1,0 +1,11 @@
+import { client } from "@/lib/fetch/client";
+import type { FavoriteItemType } from "@/types/favorite";
+
+export const fetchFavoriteItems = (
+  groupId: number,
+): Promise<FavoriteItemType[]> => {
+  return client(`/favorite/${groupId}/items`, {
+    method: "GET",
+    needAuth: true,
+  });
+};

--- a/src/lib/api/favorite.ts
+++ b/src/lib/api/favorite.ts
@@ -1,11 +1,30 @@
 import { client } from "@/lib/fetch/client";
 import type { FavoriteItemType } from "@/types/favorite";
 
+// 즐겨찾기 조회
 export const fetchFavoriteItems = (
   groupId: number,
 ): Promise<FavoriteItemType[]> => {
   return client(`/favorite/${groupId}/items`, {
     method: "GET",
     needAuth: true,
+  });
+};
+
+// 즐겨찾기 메모 수정
+export const updateFavoriteItem = async (
+  favoriteId: number,
+  memo: string,
+): Promise<void> => {
+  return await client(`/favorite/${favoriteId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ memo }),
+  });
+};
+
+// 즐겨찾기 삭제
+export const deleteFavoriteItem = async (favoriteId: number): Promise<void> => {
+  return await client(`/favorite/${favoriteId}`, {
+    method: "DELETE",
   });
 };

--- a/src/types/favorite.ts
+++ b/src/types/favorite.ts
@@ -1,0 +1,13 @@
+export interface FavoriteItemType {
+  id: number;
+  userId: number;
+  groupId: number;
+  placeId: number;
+  lat: number;
+  lng: number;
+  memo: string;
+  address: string;
+  deleted: boolean;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
즐겨찾기 그룹 API 추가와 즐겨찾기 상세 UI 와 API 추가 

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 즐겨찾기 그룹 카드에서 메뉴 모달에 수정과 삭제 API 를 연결했습니다
- 즐겨찾기 그룹 리스트에서 그룹 추가 버튼을 임시로 만들었습니다 (그룹 추가를 프로필에서도 가능하게 할지 미정)
- 즐겨찾기 그룹 리스트에서 그룹 카드 이름을 누르면 해당 그룹의 상세 리스트 페이지로 이동합니다
- 즐겨찾기 상세 페이지와 카드 UI 를 구현했습니다 (그룹 이름, 장소 개수, 즐겨찾기 상세 리스트)(카드 안 정보는 임시)
- 즐겨찾기 카드에서도 메뉴 버튼과 모달을 구현했고, 메모 수정과 즐겨찾기 삭제 API 를 연결했습니다
- 즐겨찾기 삭제 상태가 된 카드는 리스트와 장소 개수에 반영되지 않도록 추가했습니다

## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/cec7a800-1169-4077-bb8c-79e60a8eec48)
( 프로필 즐겨찾기 그룹 리스트에서 해당 그룹의 리스트 상세로 이동할 수 있음 )
( 그룹 추가 버튼 임시 구현 )
![image](https://github.com/user-attachments/assets/b1fcc2fe-1eaa-49d7-97e3-b49065ffbc8e)
( 현재 즐겨찾기 상세 리스트 )
![image](https://github.com/user-attachments/assets/546b8d8e-4426-4701-8701-e419134ad1f7)
( 메뉴 버튼 클릭 시 메모 수정 / 삭제 모달 )
![image](https://github.com/user-attachments/assets/205cc5c3-fde4-4470-a55c-a0463581c274)
( 메모를 수정 중인 상태 )

## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->
직접 실행 테스트


## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->

즐겨찾기 장소 카드에 표시할 정보는 수정할 예정입니다 !
장소 이름, 장소 주소, 메모 정도면 되지 않을까 싶은데 반환되는 어떤 정보든 더 표시할 수 있는 상태긴 합니다

즐겨찾기 상세에서 메뉴 모달에 "수정"을 "메모 수정"으로 바꾸는게 직관적이겠네요 이거는 바로 반영하겠습니다

그리고 즐겨찾기 그룹은 bookmark 라는 표현을 썼고, 즐겨찾기 상세는 favorite 표현을 사용한 상태라
API 명세에 따라 favorite 로 통일하는 리팩토링을 해야할 것 같습니다 ㅠ..
