### PR TITLE
Feat/combine-component  컴포넌트 교체, 즐겨찾기리스트 조회, 장소 상세 조회 API 연결

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -9,7 +9,7 @@ import { fetchPlaceDetail, fetchPlaceList } from "@/lib/api/map";
 import { PlaceDetailResponse, PlaceListResponse } from "@/types/map";
 
 const MapPage = () => {
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useState<number>(1);
   const [placeList, setPlaceList] = useState<PlaceListResponse | null>(null);
   const [placeId, setPlaceId] = useState<number | null>(null);
   const [placeDetail, setPlaceDetail] = useState<PlaceDetailResponse | null>(
@@ -38,7 +38,6 @@ const MapPage = () => {
           distanceKm,
         );
         setPlaceList(data);
-        setPage(2); // 장소 목록 가져온 뒤 페이지 전환
       } catch (error) {
         console.error("장소 목록을 불러오는 데 실패했습니다.", error);
       }

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import KakaoMap from "@/components/map/KakaoMap";
+import SideMenu from "@/components/map/SideMenu";
+import PlaceModal from "@/components/map/PlaceModal";
+import PlaceUserMemos from "@/components/map/PlaceUserMemos";
 
 const MapPage = () => {
   return (
     <div>
       <KakaoMap />
+      <SideMenu />
+      <PlaceModal />
+      <PlaceUserMemos />
     </div>
   );
 };

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -12,13 +12,16 @@ const MapPage = () => {
 
   const [page, setPage] = useState(1);
   const [placeList, setPlaceList] = useState<PlaceListResponse | null>(null);
-  const [placeId, setPlaceId] = useState();
+  const [placeId, setPlaceId] = useState<number | null>(null);
   const [placeDetail, setPlaceDetail] = useState<PlaceDetailResponse | null>(null);
 
+  function handleClick(placeId: number | undefined) {
+    setPlaceId(placeId);
+  }
 
   useEffect(() => {
     const lat = 37.554722;
-    const lng = 126.970833;
+    const lng = 126.97083;
     const distanceKm = 5;
 
     (async () => {
@@ -37,9 +40,9 @@ const MapPage = () => {
     if (placeId !== null) {
       (async () => {
         try {
-          const data = await fetchPlaceDetail(3);
+          const data = await fetchPlaceDetail(placeId); // ✅ 동적 ID 사용
           setPlaceDetail(data);
-          // setPage(2);
+          setPage(2);
         } catch (error) {
           console.error("장소 상세 정보를 불러오는 데 실패했습니다.", error);
         }
@@ -52,7 +55,7 @@ const MapPage = () => {
       <KakaoMap />
       <SideMenu />
 
-      <PlaceModal placeList={placeList}></PlaceModal>
+      <PlaceModal onClick={handleClick} placeList={placeList}></PlaceModal>
       <PlaceUserMemos placeDetail={placeDetail} />
     </div>
   );

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -6,10 +6,11 @@ import PlaceModal from "@/components/map/PlaceModal";
 import PlaceUserMemos from "@/components/map/PlaceUserMemos";
 import { useEffect, useState } from "react";
 import { fetchPlaceDetail, fetchPlaceList } from "@/lib/api/map";
-import { PlaceDetailResponse, PlaceListResponse } from "@/types/map";
+import { PAGE, PageType, PlaceDetailResponse, PlaceListResponse } from "@/types/map";
 
 const MapPage = () => {
-  const [page, setPage] = useState<number>(1);
+
+  const [page, setPage] = useState<PageType>(PAGE.PLACELIST);
   const [placeList, setPlaceList] = useState<PlaceListResponse | null>(null);
   const [placeId, setPlaceId] = useState<number | null>(null);
   const [placeDetail, setPlaceDetail] = useState<PlaceDetailResponse | null>(
@@ -18,11 +19,11 @@ const MapPage = () => {
 
   function handleClick(placeId: number) {
     setPlaceId(placeId);
-    setPage(2);
+    setPage(PAGE.PLACEDETAIL);
   }
 
   function backPage() {
-    setPage(1);
+    setPage(PAGE.PLACELIST);
   }
 
   useEffect(() => {
@@ -48,7 +49,7 @@ const MapPage = () => {
     if (placeId !== null) {
       (async () => {
         try {
-          const data = await fetchPlaceDetail(placeId); // ✅ 동적 ID 사용
+          const data = await fetchPlaceDetail(placeId);
           setPlaceDetail(data);
         } catch (error) {
           console.error("장소 상세 정보를 불러오는 데 실패했습니다.", error);
@@ -62,10 +63,10 @@ const MapPage = () => {
       <KakaoMap />
       <SideMenu />
 
-      {page == 1 && placeList && (
+      {page === PAGE.PLACELIST && placeList && (
         <PlaceModal onClick={handleClick} placeList={placeList}></PlaceModal>
       )}
-      {page == 2 && placeDetail && (
+      {page == PAGE.PLACEDETAIL && placeDetail && (
         <PlaceUserMemos backPage={backPage} placeDetail={placeDetail} />
       )}
     </div>

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -9,14 +9,20 @@ import { fetchPlaceDetail, fetchPlaceList } from "@/lib/api/map";
 import { PlaceDetailResponse, PlaceListResponse } from "@/types/map";
 
 const MapPage = () => {
-
   const [page, setPage] = useState(1);
   const [placeList, setPlaceList] = useState<PlaceListResponse | null>(null);
   const [placeId, setPlaceId] = useState<number | null>(null);
-  const [placeDetail, setPlaceDetail] = useState<PlaceDetailResponse | null>(null);
+  const [placeDetail, setPlaceDetail] = useState<PlaceDetailResponse | null>(
+    null,
+  );
 
-  function handleClick(placeId: number | undefined) {
+  function handleClick(placeId: number) {
     setPlaceId(placeId);
+    setPage(2);
+  }
+
+  function backPage() {
+    setPage(1);
   }
 
   useEffect(() => {
@@ -26,15 +32,18 @@ const MapPage = () => {
 
     (async () => {
       try {
-        const data = await fetchPlaceList(lat, lng, distanceKm);
+        const data: PlaceListResponse = await fetchPlaceList(
+          lat,
+          lng,
+          distanceKm,
+        );
         setPlaceList(data);
-        // setPage(2); // 장소 목록 가져온 뒤 페이지 전환
+        setPage(2); // 장소 목록 가져온 뒤 페이지 전환
       } catch (error) {
         console.error("장소 목록을 불러오는 데 실패했습니다.", error);
       }
     })();
   }, []);
-
 
   useEffect(() => {
     if (placeId !== null) {
@@ -42,7 +51,6 @@ const MapPage = () => {
         try {
           const data = await fetchPlaceDetail(placeId); // ✅ 동적 ID 사용
           setPlaceDetail(data);
-          setPage(2);
         } catch (error) {
           console.error("장소 상세 정보를 불러오는 데 실패했습니다.", error);
         }
@@ -55,8 +63,12 @@ const MapPage = () => {
       <KakaoMap />
       <SideMenu />
 
-      <PlaceModal onClick={handleClick} placeList={placeList}></PlaceModal>
-      <PlaceUserMemos placeDetail={placeDetail} />
+      {page == 1 && placeList && (
+        <PlaceModal onClick={handleClick} placeList={placeList}></PlaceModal>
+      )}
+      {page == 2 && placeDetail && (
+        <PlaceUserMemos backPage={backPage} placeDetail={placeDetail} />
+      )}
     </div>
   );
 };

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -4,14 +4,56 @@ import KakaoMap from "@/components/map/KakaoMap";
 import SideMenu from "@/components/map/SideMenu";
 import PlaceModal from "@/components/map/PlaceModal";
 import PlaceUserMemos from "@/components/map/PlaceUserMemos";
+import { useEffect, useState } from "react";
+import { fetchPlaceDetail, fetchPlaceList } from "@/lib/api/map";
+import { PlaceDetailResponse, PlaceListResponse } from "@/types/map";
 
 const MapPage = () => {
+
+  const [page, setPage] = useState(1);
+  const [placeList, setPlaceList] = useState<PlaceListResponse | null>(null);
+  const [placeId, setPlaceId] = useState();
+  const [placeDetail, setPlaceDetail] = useState<PlaceDetailResponse | null>(null);
+
+
+  useEffect(() => {
+    const lat = 37.554722;
+    const lng = 126.970833;
+    const distanceKm = 5;
+
+    (async () => {
+      try {
+        const data = await fetchPlaceList(lat, lng, distanceKm);
+        setPlaceList(data);
+        // setPage(2); // 장소 목록 가져온 뒤 페이지 전환
+      } catch (error) {
+        console.error("장소 목록을 불러오는 데 실패했습니다.", error);
+      }
+    })();
+  }, []);
+
+
+  useEffect(() => {
+    if (placeId !== null) {
+      (async () => {
+        try {
+          const data = await fetchPlaceDetail(3);
+          setPlaceDetail(data);
+          // setPage(2);
+        } catch (error) {
+          console.error("장소 상세 정보를 불러오는 데 실패했습니다.", error);
+        }
+      })();
+    }
+  }, [placeId]);
+
   return (
     <div>
       <KakaoMap />
       <SideMenu />
-      <PlaceModal />
-      <PlaceUserMemos />
+
+      <PlaceModal placeList={placeList}></PlaceModal>
+      <PlaceUserMemos placeDetail={placeDetail} />
     </div>
   );
 };

--- a/src/components/map/BookmarkInfo.tsx
+++ b/src/components/map/BookmarkInfo.tsx
@@ -9,34 +9,42 @@ interface BookmarkInfoProps {
 
 export function BookmarkInfo({ placeDetail }: BookmarkInfoProps) {
   return (
-    <>
-      <ul className="flex -space-x-6">
-        {placeDetail?.usersInfo.slice(0, 3).map((user, idx) => (
-          <li
-            className="flex items-center justify-center rounded-full w-11 h-11 border-2 border-gray200"
-            key={idx}
-          >
-            <button>
-              <Image
-                src={getProfileImageUrl(user.profileImage)}
-                alt="유저 이미지"
-                className="rounded-full border-1 border-gray200 flex-shrink-0"
-                width="40"
-                height="40"
-              />
+    <div className="flex items-center space-x-2 justify-center pb-4">
+      {placeDetail?.favoriteCount == 0 ? (
+        <div className="text-xs">
+          <span> 아무도 해당 장소를 즐겨찾기에 등록하지 않았습니다.</span>
+        </div>
+      ) : (
+        <>
+          <ul className="flex -space-x-6">
+            {placeDetail?.usersInfo.slice(0, 3).map((user, idx) => (
+              <li
+                className="flex items-center justify-center rounded-full w-11 h-11 border-2 border-gray200"
+                key={idx}
+              >
+                <button>
+                  <Image
+                    src={getProfileImageUrl(user.profileImage)}
+                    alt="유저 이미지"
+                    className="rounded-full border-1 border-gray200 flex-shrink-0"
+                    width="40"
+                    height="40"
+                  />
+                </button>
+              </li>
+            ))}
+          </ul>
+          <div className="text-xs">
+            <button className="font-bold">
+              {placeDetail?.usersInfo[0].nickname}
             </button>
-          </li>
-        ))}
-      </ul>
-      <div className="text-xs">
-        <button className="font-bold">
-          {placeDetail?.usersInfo[0].nickname}
-        </button>
-        <span>
-          {" "}
-          님 외 {placeDetail?.favoriteCount} 명이 즐겨찾기에 추가했습니다.
-        </span>
-      </div>
-    </>
+            <span>
+              {" "}
+              님 외 {placeDetail?.favoriteCount} 명이 즐겨찾기에 추가했습니다.
+            </span>
+          </div>
+        </>
+      )}
+    </div>
   );
 }

--- a/src/components/map/BookmarkInfo.tsx
+++ b/src/components/map/BookmarkInfo.tsx
@@ -4,29 +4,39 @@ import React from "react";
 import { PlaceDetailResponse } from "@/types/map";
 
 interface BookmarkInfoProps {
-  placeDetail : PlaceDetailResponse;
+  placeDetail: PlaceDetailResponse;
 }
 
-export function BookmarkInfo( {placeDetail}: BookmarkInfoProps ) {
-
-  return(
-    <ul className="flex -space-x-6">
-      {placeDetail?.usersInfo.slice(0, 3).map((user, idx) => (
-        <li
-          className="flex items-center justify-center rounded-full w-11 h-11 border-2 border-gray200"
-          key={idx}
-        >
-          <button>
-            <Image
-              src={getProfileImageUrl(user.profileImage)}
-              alt="유저 이미지"
-              className="rounded-full border-1 border-gray200 flex-shrink-0"
-              width="40"
-              height="40"
-            />
-          </button>
-        </li>
-      ))}
-    </ul>
+export function BookmarkInfo({ placeDetail }: BookmarkInfoProps) {
+  return (
+    <>
+      <ul className="flex -space-x-6">
+        {placeDetail?.usersInfo.slice(0, 3).map((user, idx) => (
+          <li
+            className="flex items-center justify-center rounded-full w-11 h-11 border-2 border-gray200"
+            key={idx}
+          >
+            <button>
+              <Image
+                src={getProfileImageUrl(user.profileImage)}
+                alt="유저 이미지"
+                className="rounded-full border-1 border-gray200 flex-shrink-0"
+                width="40"
+                height="40"
+              />
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="text-xs">
+        <button className="font-bold">
+          {placeDetail?.usersInfo[0].nickname}
+        </button>
+        <span>
+          {" "}
+          님 외 {placeDetail?.favoriteCount} 명이 즐겨찾기에 추가했습니다.
+        </span>
+      </div>
+    </>
   );
 }

--- a/src/components/map/BookmarkInfo.tsx
+++ b/src/components/map/BookmarkInfo.tsx
@@ -1,0 +1,32 @@
+import Image from "next/image";
+import { getProfileImageUrl } from "@/utils/image";
+import React from "react";
+import { PlaceDetailResponse } from "@/types/map";
+
+interface BookmarkInfoProps {
+  placeDetail : PlaceDetailResponse;
+}
+
+export function BookmarkInfo( {placeDetail}: BookmarkInfoProps ) {
+
+  return(
+    <ul className="flex -space-x-6">
+      {placeDetail?.usersInfo.slice(0, 3).map((user, idx) => (
+        <li
+          className="flex items-center justify-center rounded-full w-11 h-11 border-2 border-gray200"
+          key={idx}
+        >
+          <button>
+            <Image
+              src={getProfileImageUrl(user.profileImage)}
+              alt="유저 이미지"
+              className="rounded-full border-1 border-gray200 flex-shrink-0"
+              width="40"
+              height="40"
+            />
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -1,9 +1,6 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import SideMenu from "./SideMenu";
-import PlaceModal from "@/components/map/PlaceModal";
-import PlaceUserMemos from "@/components/map/PlaceUserMemos";
 
 // Kakao 객체를 전역 선언합니다.
 declare global {

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -8,7 +8,10 @@ declare global {
     kakao: {
       maps: {
         LatLng: new (lat: number, lng: number) => void;
-        Map: new (container: HTMLElement, options: { center: void, level: number }) => void;
+        Map: new (
+          container: HTMLElement,
+          options: { center: void; level: number },
+        ) => void;
         load: (callback: () => void) => void;
       };
     };
@@ -46,7 +49,7 @@ export default function KakaoMap() {
 
   return (
     <>
-      <div ref={mapRef} className={`w-screen h-screen`}/>
+      <div ref={mapRef} className={`w-screen h-screen`} />
     </>
   );
 }

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -50,9 +50,6 @@ export default function KakaoMap() {
   return (
     <>
       <div ref={mapRef} className={`w-screen h-screen`}/>
-      <SideMenu />
-      <PlaceModal />
-      <PlaceUserMemos />
     </>
   );
 }

--- a/src/components/map/PlaceCard.tsx
+++ b/src/components/map/PlaceCard.tsx
@@ -31,7 +31,7 @@ export default function PlaceCard({
   onClick,
 }: PlaceCardProps) {
   return (
-    <div
+    <li
       className="flex items-center hover:bg-gray-100 transition p-1"
       onClick={onClick}
     >
@@ -44,6 +44,6 @@ export default function PlaceCard({
         <p className="text-sm text-gray600">{address}</p>
         <p className="text-sm text-gray-400">즐겨찾기 {favoriteCount}개</p>
       </div>
-    </div>
+    </li>
   );
 }

--- a/src/components/map/PlaceCard.tsx
+++ b/src/components/map/PlaceCard.tsx
@@ -8,6 +8,7 @@ import {
 import { JSX } from "react";
 
 interface PlaceCardProps {
+  placeId: number;
   placeName: string;
   address: string;
   category: string;
@@ -24,6 +25,7 @@ const categoryIcons: Record<string, JSX.Element> = {
 };
 
 export default function PlaceCard({
+  placeId,
   placeName,
   address,
   category,
@@ -34,6 +36,7 @@ export default function PlaceCard({
     <li
       className="flex items-center hover:bg-gray-100 transition p-1"
       onClick={onClick}
+      key={placeId}
     >
       {/* 이미지 영역 */}
       <div className="flex w-14 h-14 items-center justify-center mr-4 border border-gray-300 rounded-full">

--- a/src/components/map/PlaceCard.tsx
+++ b/src/components/map/PlaceCard.tsx
@@ -1,4 +1,10 @@
-import { Food, Cafe, Etc, Market, Favorite } from "@/components/common/Icons/category";
+import {
+  Cafe,
+  Etc,
+  Favorite,
+  Food,
+  Market,
+} from "@/components/common/Icons/category";
 import { JSX } from "react";
 
 interface PlaceCardProps {
@@ -6,25 +12,29 @@ interface PlaceCardProps {
   address: string;
   category: string;
   favoriteCount: number;
+  onClick?: () => void; // 클릭 시 동작할 함수
 }
 
 const categoryIcons: Record<string, JSX.Element> = {
   Food: <Food />,
   Cafe: <Cafe />,
   Market: <Market />,
-  Etc : <Etc />,
-  Favorite : <Favorite />
+  Etc: <Etc />,
+  Favorite: <Favorite />,
 };
-
 
 export default function PlaceCard({
   placeName,
   address,
   category,
   favoriteCount,
+  onClick,
 }: PlaceCardProps) {
   return (
-    <div className="flex items-center hover:bg-gray-100 transition p-1">
+    <div
+      className="flex items-center hover:bg-gray-100 transition p-1"
+      onClick={onClick}
+    >
       {/* 이미지 영역 */}
       <div className="flex w-14 h-14 items-center justify-center mr-4 border border-gray-300 rounded-full">
         {categoryIcons[category] || <Etc />}

--- a/src/components/map/PlaceCard.tsx
+++ b/src/components/map/PlaceCard.tsx
@@ -24,12 +24,12 @@ export default function PlaceCard({
   favoriteCount,
 }: PlaceCardProps) {
   return (
-    <div className="flex items-center">
+    <div className="flex items-center hover:bg-gray-100 transition p-1">
       {/* 이미지 영역 */}
       <div className="flex w-14 h-14 items-center justify-center mr-4 border border-gray-300 rounded-full">
         {categoryIcons[category] || <Etc />}
       </div>
-      <div className="flex-1 p-3 shadow-sm hover:bg-gray-100 transition">
+      <div className="flex-1 p-3 shadow-sm ">
         <h3 className="font-bold text-base ">{placeName}</h3>
         <p className="text-sm text-gray600">{address}</p>
         <p className="text-sm text-gray-400">즐겨찾기 {favoriteCount}개</p>

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -27,6 +27,7 @@ export default function PlaceModal( { placeList, onClick } : PlaceModalProps ) {
         {placeList?.placeInfos.map((place) => (
           <PlaceCard
             key={place.placeId}
+            placeId={place.placeId}
             category={place.category}
             placeName={place.name}
             address={place.address}

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -23,7 +23,7 @@ export default function PlaceModal( { placeList, onClick } : PlaceModalProps ) {
       </div>
 
       {/* 장소 카드 리스트 */}
-      <div className="flex flex-col gap-3 px-4 py-4 overflow-y-auto">
+      <ul className="flex flex-col gap-3 px-4 py-4 overflow-y-auto">
         {placeList?.placeInfos.map((place) => (
           <PlaceCard
             key={place.placeId}
@@ -34,7 +34,7 @@ export default function PlaceModal( { placeList, onClick } : PlaceModalProps ) {
             onClick={()=> onClick(place.placeId)}
           />
         ))}
-      </div>
+      </ul>
     </div>
   );
 }

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -2,14 +2,12 @@ import React from "react";
 import PlaceCard from "@/components/map/PlaceCard";
 import { PlaceListResponse } from "@/types/map";
 
-
 interface PlaceModalProps {
-  placeList : PlaceListResponse;
-  onClick : (placeId: number) => void;
+  placeList: PlaceListResponse;
+  onClick: (placeId: number) => void;
 }
 
-export default function PlaceModal( { placeList, onClick } : PlaceModalProps ) {
-
+export default function PlaceModal({ placeList, onClick }: PlaceModalProps) {
   return (
     <div className="flex flex-col absolute -bottom-4 left-4 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
       {/* 헤더 */}
@@ -32,7 +30,7 @@ export default function PlaceModal( { placeList, onClick } : PlaceModalProps ) {
             placeName={place.name}
             address={place.address}
             favoriteCount={place.favoriteCount}
-            onClick={()=> onClick(place.placeId)}
+            onClick={() => onClick(place.placeId)}
           />
         ))}
       </ul>

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -1,57 +1,13 @@
 import React from "react";
 import PlaceCard from "@/components/map/PlaceCard";
+import { PlaceListResponse } from "@/types/map";
 
-export default function PlaceModal() {
-  const dummyData = {
-    totalCount: 5,
-    placeInfos: [
-      {
-        place_id: 1,
-        placeName: "갓덴 스시 강남점",
-        address: "서울의 어딘가 123",
-        category: "Food",
-        favoriteCount: 10,
-        lat: 36.123,
-        lng: 127.232,
-      },
-      {
-        place_id: 2,
-        placeName: "신동궁 감자탕 역삼직영",
-        address: "서울의 어딘가 1234",
-        category: "Cafe",
-        favoriteCount: 5,
-        lat: 36.123,
-        lng: 127.232,
-      },
-      {
-        place_id: 3,
-        placeName: "장인 닭갈비 강남점",
-        address: "서울의 어딘가 123 345",
-        category: "Etc",
-        favoriteCount: 12,
-        lat: 36.123,
-        lng: 127.232,
-      },
-      {
-        place_id: 4,
-        placeName: "장소1",
-        address: "서울의 어딘가 123 3211",
-        category: "Market",
-        favoriteCount: 11,
-        lat: 36.123,
-        lng: 127.232,
-      },
-      {
-        place_id: 5,
-        placeName: "장소2",
-        address: "서울의 어딘가 123 3211",
-        category: "Favorite",
-        favoriteCount: 5,
-        lat: 36.123,
-        lng: 127.232,
-      },
-    ],
-  };
+
+interface PlaceModalProps {
+  placeList : PlaceListResponse;
+}
+
+export default function PlaceModal( { placeList } : PlaceModalProps ) {
 
   return (
     <div className="flex flex-col absolute -bottom-4 left-4 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
@@ -67,7 +23,7 @@ export default function PlaceModal() {
 
       {/* 장소 카드 리스트 */}
       <div className="flex flex-col gap-3 px-4 py-4 overflow-y-auto">
-        {dummyData.placeInfos.map((place) => (
+        {placeList?.placeInfos.map((place) => (
           <PlaceCard
             key={place.place_id}
             category={place.category}

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -5,9 +5,10 @@ import { PlaceListResponse } from "@/types/map";
 
 interface PlaceModalProps {
   placeList : PlaceListResponse;
+  onClick : (placeId: number) => void;
 }
 
-export default function PlaceModal( { placeList } : PlaceModalProps ) {
+export default function PlaceModal( { placeList, onClick } : PlaceModalProps ) {
 
   return (
     <div className="flex flex-col absolute -bottom-4 left-4 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
@@ -25,11 +26,12 @@ export default function PlaceModal( { placeList } : PlaceModalProps ) {
       <div className="flex flex-col gap-3 px-4 py-4 overflow-y-auto">
         {placeList?.placeInfos.map((place) => (
           <PlaceCard
-            key={place.place_id}
+            key={place.placeId}
             category={place.category}
             placeName={place.name}
             address={place.address}
             favoriteCount={place.favoriteCount}
+            onClick={()=> onClick(place.placeId)}
           />
         ))}
       </div>

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -27,7 +27,7 @@ export default function PlaceModal( { placeList } : PlaceModalProps ) {
           <PlaceCard
             key={place.place_id}
             category={place.category}
-            placeName={place.placeName}
+            placeName={place.name}
             address={place.address}
             favoriteCount={place.favoriteCount}
           />

--- a/src/components/map/PlaceUserMemos.tsx
+++ b/src/components/map/PlaceUserMemos.tsx
@@ -58,16 +58,16 @@ export default function PlaceUserMemos({ placeDetail, backPage }: PlaceUserMemos
             <ul className="flex -space-x-6">
               {placeDetail?.usersInfo.slice(0, 3).map((user, idx) => (
                 <li
-                  className="flex items-center justify-center rounded-full w-10 h-10 border-2 border-gray200"
+                  className="flex items-center justify-center rounded-full w-11 h-11 border-2 border-gray200"
                   key={idx}
                 >
                   <button>
                     <Image
                       src={getProfileImageUrl(user.profileImage)}
                       alt="유저 이미지"
-                      className="rounded-full w-10 h-10 border-1 border-gray200 flex-shrink-0"
-                      width="28"
-                      height="28"
+                      className="rounded-full border-1 border-gray200 flex-shrink-0"
+                      width="40"
+                      height="40"
                     />
                   </button>
                 </li>

--- a/src/components/map/PlaceUserMemos.tsx
+++ b/src/components/map/PlaceUserMemos.tsx
@@ -29,15 +29,9 @@ export default function PlaceUserMemos({ placeDetail, backPage }: PlaceUserMemos
           </button>
 
           <div className="flex items-center space-x-2">
-            {favorite ? (
-              <button onClick={handleClickFavorite} className="flex self-start">
-                <LucideStar />
-              </button>
-            ) : (
-              <button onClick={handleClickFavorite} className="flex self-start">
-                <LucideStar className="text-yellow-400 fill-yellow-400" />
-              </button>
-            )}
+            <button onClick={handleClickFavorite} className="flex self-start">
+              <LucideStar className={favorite ? " " : "text-yellow-400 fill-yellow-400"} />
+            </button>
 
             <div className="flex flex-col justify-center items-center text-center max-w-[200px]">
               <span className="font-bold text-gray900 text-lg leading-snug break-words">

--- a/src/components/map/PlaceUserMemos.tsx
+++ b/src/components/map/PlaceUserMemos.tsx
@@ -1,100 +1,26 @@
-import React, { useState } from "react";
-import UserMemoCard from "@/components/map/UserMemoCard";
-import { ArrowLeftIcon, LucideStar, MoreVerticalIcon } from "lucide-react";
+import React from "react";
 import { PlaceDetailResponse } from "@/types/map";
-import Image from "next/image";
-import { getProfileImageUrl } from "@/utils/image";
+import PlaceUserMemosHeader from "@/components/map/PlaceUserMemosHeader";
+import { BookmarkInfo } from "@/components/map/BookmarkInfo";
+import { UserMemoCards } from "@/components/map/UserMemoCards";
 
 interface PlaceUserMemosProps {
   placeDetail: PlaceDetailResponse;
   backPage: () => void;
 }
 
-export default function PlaceUserMemos({ placeDetail, backPage }: PlaceUserMemosProps) {
-  const [favorite, setFavorite] = useState(false);
-
-  function handleClickFavorite() {
-    setFavorite((prev) => !prev);
-  }
-
+export default function PlaceUserMemos({
+  placeDetail,
+  backPage,
+}: PlaceUserMemosProps) {
   return (
     <div className="flex flex-col absolute -bottom-4 left-4 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
-      <div className="relative w-full px-4 py-4">
-
-
-        <div className="flex flex-col items-center justify-center">
-          <button className="absolute left-4 top-4"
-            onClick={backPage}>
-            <ArrowLeftIcon />
-          </button>
-
-          <div className="flex items-center space-x-2">
-            <button onClick={handleClickFavorite} className="flex self-start">
-              <LucideStar className={favorite ? " " : "text-yellow-400 fill-yellow-400"} />
-            </button>
-
-            <div className="flex flex-col justify-center items-center text-center max-w-[200px]">
-              <span className="font-bold text-gray900 text-lg leading-snug break-words">
-                {placeDetail?.placeName}
-              </span>
-              <span className="text-xs text-gray600 leading-snug break-words">
-                {placeDetail?.address}
-              </span>
-            </div>
-            <button className="absolute top-4 right-4 w-5 h-5 mt-0.5">
-              <MoreVerticalIcon />
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <div className="flex items-center space-x-2 justify-center pb-4">
-        {placeDetail?.favoriteCount == 0 ? (
-          <div className="text-xs">
-            <span> 아무도 해당 장소를 즐겨찾기에 등록하지 않았습니다.</span>
-          </div>
-        ) : (
-          <>
-            <ul className="flex -space-x-6">
-              {placeDetail?.usersInfo.slice(0, 3).map((user, idx) => (
-                <li
-                  className="flex items-center justify-center rounded-full w-11 h-11 border-2 border-gray200"
-                  key={idx}
-                >
-                  <button>
-                    <Image
-                      src={getProfileImageUrl(user.profileImage)}
-                      alt="유저 이미지"
-                      className="rounded-full border-1 border-gray200 flex-shrink-0"
-                      width="40"
-                      height="40"
-                    />
-                  </button>
-                </li>
-              ))}
-            </ul>
-            <div className="text-xs">
-              <button className="font-bold">
-                {placeDetail?.usersInfo[0].nickname}
-              </button>
-              <span>
-                {" "}
-                님 외 {placeDetail?.favoriteCount} 명이 즐겨찾기에 추가했습니다.
-              </span>
-            </div>
-          </>
-        )}
-      </div>
-      <ul className="flex flex-col gap-3 px-4 py-4 overflow-y-auto">
-        {placeDetail?.usersInfo.map((user) => (
-          <UserMemoCard
-            key={user.userId}
-            profileImage={user.profileImage}
-            nickName={user.nickname}
-            memo={user.memo}
-          />
-        ))}
-      </ul>
+      {/* 헤더 */}
+      <PlaceUserMemosHeader placeDetail={placeDetail} backPage={backPage} />
+      {/* 즐겨찾기 정보 */}
+      <BookmarkInfo placeDetail={placeDetail} />
+      {/* 유저 메모 리스트 */}
+      <UserMemoCards placeDetail={placeDetail} />
     </div>
   );
 }

--- a/src/components/map/PlaceUserMemos.tsx
+++ b/src/components/map/PlaceUserMemos.tsx
@@ -26,10 +26,7 @@ export default function PlaceUserMemos({ placeDetail }: PlaceUserMemosProps) {
         <div className="flex flex-col items-center justify-center">
           <div className="flex items-center space-x-2">
             {favorite ? (
-              <button
-                onClick={handleClickFavorite}
-                className="flex self-start "
-              >
+              <button onClick={handleClickFavorite} className="flex self-start">
                 <LucideStar />
               </button>
             ) : (
@@ -37,12 +34,13 @@ export default function PlaceUserMemos({ placeDetail }: PlaceUserMemosProps) {
                 <LucideStar className="text-yellow-400 fill-yellow-400" />
               </button>
             )}
-            <div className="flex flex-col justify-center">
-              <span className="font-bold text-gray900 text-lg leading-snug">
+
+            {/* 텍스트 영역 */}
+            <div className="flex flex-col justify-center items-center text-center max-w-[200px]">
+              <span className="font-bold text-gray900 text-lg leading-snug break-words">
                 {placeDetail?.placeName}
               </span>
-
-              <span className="text-xs text-gray600 leading-snug">
+              <span className="text-xs text-gray600 leading-snug break-words">
                 {placeDetail?.address}
               </span>
             </div>

--- a/src/components/map/PlaceUserMemos.tsx
+++ b/src/components/map/PlaceUserMemos.tsx
@@ -1,15 +1,16 @@
 import React, { useState } from "react";
 import UserMemoCard from "@/components/map/UserMemoCard";
-import { LucideStar, MoreVerticalIcon } from "lucide-react";
+import { ArrowLeftIcon, LucideStar, MoreVerticalIcon } from "lucide-react";
 import { PlaceDetailResponse } from "@/types/map";
 import Image from "next/image";
 import { getProfileImageUrl } from "@/utils/image";
 
 interface PlaceUserMemosProps {
   placeDetail: PlaceDetailResponse;
+  backPage: () => void;
 }
 
-export default function PlaceUserMemos({ placeDetail }: PlaceUserMemosProps) {
+export default function PlaceUserMemos({ placeDetail, backPage }: PlaceUserMemosProps) {
   const [favorite, setFavorite] = useState(false);
 
   function handleClickFavorite() {
@@ -17,13 +18,16 @@ export default function PlaceUserMemos({ placeDetail }: PlaceUserMemosProps) {
   }
 
   return (
-    <div className="flex flex-col absolute left-[400px] -bottom-4 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
+    <div className="flex flex-col absolute -bottom-4 left-4 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
       <div className="relative w-full px-4 py-4">
-        <button className="absolute top-4 right-4 w-5 h-5 mt-0.5">
-          <MoreVerticalIcon />
-        </button>
+
 
         <div className="flex flex-col items-center justify-center">
+          <button className="absolute left-4 top-4"
+            onClick={backPage}>
+            <ArrowLeftIcon />
+          </button>
+
           <div className="flex items-center space-x-2">
             {favorite ? (
               <button onClick={handleClickFavorite} className="flex self-start">
@@ -35,7 +39,6 @@ export default function PlaceUserMemos({ placeDetail }: PlaceUserMemosProps) {
               </button>
             )}
 
-            {/* 텍스트 영역 */}
             <div className="flex flex-col justify-center items-center text-center max-w-[200px]">
               <span className="font-bold text-gray900 text-lg leading-snug break-words">
                 {placeDetail?.placeName}
@@ -44,6 +47,9 @@ export default function PlaceUserMemos({ placeDetail }: PlaceUserMemosProps) {
                 {placeDetail?.address}
               </span>
             </div>
+            <button className="absolute top-4 right-4 w-5 h-5 mt-0.5">
+              <MoreVerticalIcon />
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/map/PlaceUserMemos.tsx
+++ b/src/components/map/PlaceUserMemos.tsx
@@ -1,47 +1,16 @@
 import React, { useState } from "react";
 import UserMemoCard from "@/components/map/UserMemoCard";
-import { LucideStar, MoreVerticalIcon} from "lucide-react";
+import { LucideStar, MoreVerticalIcon } from "lucide-react";
 import { PlaceDetailResponse } from "@/types/map";
 import Image from "next/image";
 import { getProfileImageUrl } from "@/utils/image";
 
-export default function PlaceUserMemos() {
-  const [favorite, setFavorite] = useState(false);
+interface PlaceUserMemosProps {
+  placeDetail: PlaceDetailResponse;
+}
 
-  const dummyData: PlaceDetailResponse = {
-    placeId: 1,
-    placeName: "갓덴 스시 강남점",
-    address: "서울의 어딘가 123",
-    lat: 36.123,
-    lng: 127.232,
-    favoriteCount: 5,
-    userInfo: [
-      {
-        userId: 1,
-        profileImage: "/icons/sampleProfile.svg",
-        nickname: "이브니",
-        memo: "요기 맛없어요asdsadasdasdasdasasdasd1",
-      },
-      {
-        userId: 2,
-        profileImage: "",
-        nickname: "삼브니",
-        memo: "요기 맛없어asdasdasdsalkdjaslkdjaslkdjalskj2",
-      },
-      {
-        userId: 3,
-        profileImage: "",
-        nickname: "사브니",
-        memo: "요기 맛없어요3",
-      },
-      {
-        userId: 4,
-        profileImage: "/icons/sampleProfile.svg",
-        nickname: "오브니",
-        memo: "요기 맛없어요4",
-      },
-    ],
-  };
+export default function PlaceUserMemos({ placeDetail }: PlaceUserMemosProps) {
+  const [favorite, setFavorite] = useState(false);
 
   function handleClickFavorite() {
     setFavorite((prev) => !prev);
@@ -57,21 +26,24 @@ export default function PlaceUserMemos() {
         <div className="flex flex-col items-center justify-center">
           <div className="flex items-center space-x-2">
             {favorite ? (
-              <button onClick={handleClickFavorite} className="flex self-start ">
+              <button
+                onClick={handleClickFavorite}
+                className="flex self-start "
+              >
                 <LucideStar />
               </button>
             ) : (
-              <button onClick={handleClickFavorite}  className="flex self-start">
+              <button onClick={handleClickFavorite} className="flex self-start">
                 <LucideStar className="text-yellow-400 fill-yellow-400" />
               </button>
             )}
             <div className="flex flex-col justify-center">
               <span className="font-bold text-gray900 text-lg leading-snug">
-                {dummyData.placeName}
+                {placeDetail?.placeName}
               </span>
 
               <span className="text-xs text-gray600 leading-snug">
-                {dummyData.address}
+                {placeDetail?.address}
               </span>
             </div>
           </div>
@@ -79,24 +51,25 @@ export default function PlaceUserMemos() {
       </div>
 
       <div className="flex items-center space-x-2 justify-center pb-4">
-        {dummyData.favoriteCount == 0 ? (
+        {placeDetail?.favoriteCount == 0 ? (
           <div className="text-xs">
             <span> 아무도 해당 장소를 즐겨찾기에 등록하지 않았습니다.</span>
           </div>
         ) : (
           <>
             <ul className="flex -space-x-6">
-              {dummyData.userInfo.slice(0, 3).map((user, idx) => (
+              {placeDetail?.usersInfo.slice(0, 3).map((user, idx) => (
                 <li
                   className="flex items-center justify-center rounded-full w-10 h-10 border-2 border-gray200"
                   key={idx}
                 >
                   <button>
-                    <Image src={getProfileImageUrl(user.profileImage)}
-                           alt="유저 이미지"
-                           className="rounded-full w-10 h-10 border-1 border-gray200 flex-shrink-0"
-                           width="28"
-                           height="28"
+                    <Image
+                      src={getProfileImageUrl(user.profileImage)}
+                      alt="유저 이미지"
+                      className="rounded-full w-10 h-10 border-1 border-gray200 flex-shrink-0"
+                      width="28"
+                      height="28"
                     />
                   </button>
                 </li>
@@ -104,18 +77,18 @@ export default function PlaceUserMemos() {
             </ul>
             <div className="text-xs">
               <button className="font-bold">
-                {dummyData.userInfo[0].nickname}
+                {placeDetail?.usersInfo[0].nickname}
               </button>
               <span>
                 {" "}
-                님 외 {dummyData.favoriteCount} 명이 즐겨찾기에 추가했습니다.
+                님 외 {placeDetail?.favoriteCount} 명이 즐겨찾기에 추가했습니다.
               </span>
             </div>
           </>
         )}
       </div>
       <ul className="flex flex-col gap-3 px-4 py-4 overflow-y-auto">
-        {dummyData.userInfo.map((user) => (
+        {placeDetail?.usersInfo.map((user) => (
           <UserMemoCard
             key={user.userId}
             profileImage={user.profileImage}

--- a/src/components/map/PlaceUserMemosHeader.tsx
+++ b/src/components/map/PlaceUserMemosHeader.tsx
@@ -1,0 +1,47 @@
+import { ArrowLeftIcon, LucideStar, MoreVerticalIcon } from "lucide-react";
+import React, { useState } from "react";
+import { PlaceDetailResponse } from "@/types/map";
+
+interface PlaceUserMemosHeaderProps {
+  backPage: () => void;
+  placeDetail: PlaceDetailResponse;
+}
+
+export default function PlaceUserMemosHeader({
+  backPage,
+  placeDetail,
+}: PlaceUserMemosHeaderProps) {
+  const [favorite, setFavorite] = useState(false);
+
+  function handleClickFavorite() {
+    setFavorite((prev) => !prev);
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <button className="absolute left-4 top-4" onClick={backPage}>
+        <ArrowLeftIcon />
+      </button>
+
+      <div className="flex items-center space-x-2">
+        <button onClick={handleClickFavorite} className="flex self-start">
+          <LucideStar
+            className={favorite ? " " : "text-yellow-400 fill-yellow-400"}
+          />
+        </button>
+
+        <div className="flex flex-col justify-center items-center text-center max-w-[200px]">
+          <span className="font-bold text-gray900 text-lg leading-snug break-words">
+            {placeDetail?.placeName}
+          </span>
+          <span className="text-xs text-gray600 leading-snug break-words">
+            {placeDetail?.address}
+          </span>
+        </div>
+        <button className="absolute top-4 right-4 w-5 h-5 mt-0.5">
+          <MoreVerticalIcon />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/map/PlaceUserMemosHeader.tsx
+++ b/src/components/map/PlaceUserMemosHeader.tsx
@@ -18,29 +18,31 @@ export default function PlaceUserMemosHeader({
   }
 
   return (
-    <div className="flex flex-col items-center justify-center">
-      <button className="absolute left-4 top-4" onClick={backPage}>
-        <ArrowLeftIcon />
-      </button>
-
-      <div className="flex items-center space-x-2">
-        <button onClick={handleClickFavorite} className="flex self-start">
-          <LucideStar
-            className={favorite ? " " : "text-yellow-400 fill-yellow-400"}
-          />
+    <div className="relative w-full px-4 py-4">
+      <div className="flex flex-col items-center justify-center">
+        <button className="absolute left-4 top-4" onClick={backPage}>
+          <ArrowLeftIcon />
         </button>
 
-        <div className="flex flex-col justify-center items-center text-center max-w-[200px]">
-          <span className="font-bold text-gray900 text-lg leading-snug break-words">
-            {placeDetail?.placeName}
-          </span>
-          <span className="text-xs text-gray600 leading-snug break-words">
-            {placeDetail?.address}
-          </span>
+        <div className="flex items-center space-x-2">
+          <button onClick={handleClickFavorite} className="flex self-start">
+            <LucideStar
+              className={favorite ? " " : "text-yellow-400 fill-yellow-400"}
+            />
+          </button>
+
+          <div className="flex flex-col justify-center items-center text-center max-w-[200px]">
+            <span className="font-bold text-gray900 text-lg leading-snug break-words">
+              {placeDetail?.placeName}
+            </span>
+            <span className="text-xs text-gray600 leading-snug break-words">
+              {placeDetail?.address}
+            </span>
+          </div>
+          <button className="absolute top-4 right-4 w-5 h-5 mt-0.5">
+            <MoreVerticalIcon />
+          </button>
         </div>
-        <button className="absolute top-4 right-4 w-5 h-5 mt-0.5">
-          <MoreVerticalIcon />
-        </button>
       </div>
     </div>
   );

--- a/src/components/map/UserMemoCard.tsx
+++ b/src/components/map/UserMemoCard.tsx
@@ -2,28 +2,27 @@ import Image from "next/image";
 import { getProfileImageUrl } from "@/utils/image";
 
 interface UserMemoProps {
-  profileImage : string;
-  nickName : string;
-  memo : string;
+  profileImage: string;
+  nickName: string;
+  memo: string;
 }
 
 export default function UserMemoCard({
   profileImage,
   nickName,
-  memo
-} : UserMemoProps) {
+  memo,
+}: UserMemoProps) {
   return (
     <li className="flex items-center hover:bg-gray100 transition p-1">
       {/* 이미지 영역 */}
       <button className="flex items-center justify-center rounded-full w-11 h-11 border-2 border-gray200">
-        <Image src={getProfileImageUrl(profileImage)}
-               alt="프로필 이미지"
-               width="40"
-               height="40"
-               className="rounded-full border-1 border-gray200 flex-shrink-0"
+        <Image
+          src={getProfileImageUrl(profileImage)}
+          alt="프로필 이미지"
+          width="40"
+          height="40"
+          className="rounded-full border-1 border-gray200 flex-shrink-0"
         />
-
-        {/*<img src={profileImage} className="rounded-full w-10 h-10 border-1 border-gray200 flex-shrink-0"/>*/}
       </button>
       <div className="items-center flex p-3 shadow-sm space-x-3">
         <span className="font-bold text-base flex-shrink-0">{nickName}</span>

--- a/src/components/map/UserMemoCard.tsx
+++ b/src/components/map/UserMemoCard.tsx
@@ -15,12 +15,12 @@ export default function UserMemoCard({
   return (
     <li className="flex items-center hover:bg-gray100 transition p-1">
       {/* 이미지 영역 */}
-      <button className="flex items-center justify-center rounded-full w-10 h-10 border-2 border-gray200">
+      <button className="flex items-center justify-center rounded-full w-11 h-11 border-2 border-gray200">
         <Image src={getProfileImageUrl(profileImage)}
                alt="프로필 이미지"
-               width={28}
-               height={28}
-               className="rounded-full w-10 h-10 border-1 border-gray200 flex-shrink-0"
+               width="40"
+               height="40"
+               className="rounded-full border-1 border-gray200 flex-shrink-0"
         />
 
         {/*<img src={profileImage} className="rounded-full w-10 h-10 border-1 border-gray200 flex-shrink-0"/>*/}

--- a/src/components/map/UserMemoCards.tsx
+++ b/src/components/map/UserMemoCards.tsx
@@ -1,0 +1,23 @@
+import UserMemoCard from "@/components/map/UserMemoCard";
+import React from "react";
+import { PlaceDetailResponse } from "@/types/map";
+
+interface UserMemoCardsProps {
+  placeDetail: PlaceDetailResponse;
+}
+
+export function UserMemoCards ( {placeDetail} : UserMemoCardsProps ) {
+
+  return(
+    <ul className="flex flex-col gap-3 px-4 py-4 overflow-y-auto">
+      {placeDetail?.usersInfo.map((user) => (
+        <UserMemoCard
+          key={user.userId}
+          profileImage={user.profileImage}
+          nickName={user.nickname}
+          memo={user.memo}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/src/components/map/UserMemoCards.tsx
+++ b/src/components/map/UserMemoCards.tsx
@@ -6,9 +6,8 @@ interface UserMemoCardsProps {
   placeDetail: PlaceDetailResponse;
 }
 
-export function UserMemoCards ( {placeDetail} : UserMemoCardsProps ) {
-
-  return(
+export function UserMemoCards({ placeDetail }: UserMemoCardsProps) {
+  return (
     <ul className="flex flex-col gap-3 px-4 py-4 overflow-y-auto">
       {placeDetail?.usersInfo.map((user) => (
         <UserMemoCard

--- a/src/lib/api/map.ts
+++ b/src/lib/api/map.ts
@@ -6,9 +6,9 @@ export const fetchPlaceList = async (
   lat: number,
   lng: number,
   distanceKm: number
-): Promise<PlaceListResponse[]> => {
+): Promise<PlaceListResponse> => {
   const url = `/map/place?lat=${lat}&lng=${lng}&distanceKm=${distanceKm}`;
-  return await client<PlaceListResponse[]>(url, {
+  return await client<PlaceListResponse>(url, {
     method: "GET",
   });
 };

--- a/src/lib/api/map.ts
+++ b/src/lib/api/map.ts
@@ -1,0 +1,20 @@
+import { client } from "@/lib/fetch/client";
+import { PlaceListResponse, PlaceDetailResponse } from "@/types/map";
+
+// lat, lng, distanceKm을 파라미터로 받아 사용
+export const fetchPlaceList = async (
+  lat: number,
+  lng: number,
+  distanceKm: number
+): Promise<PlaceListResponse[]> => {
+  const url = `/map/place?lat=${lat}&lng=${lng}&distanceKm=${distanceKm}`;
+  return await client<PlaceListResponse[]>(url, {
+    method: "GET",
+  });
+};
+
+export const fetchPlaceDetail = async (placeId: number): Promise<PlaceDetailResponse> => {
+  return await client<PlaceDetailResponse>(`/map/place/${placeId}`, {
+    method: "GET",
+  });
+};

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -5,15 +5,31 @@ export interface PlaceDetailResponse {
   address: string;
   lat: number;
   lng: number;
+  category: string;
   favoriteCount: number;
-  userInfo: UserInfo[];
+  usersInfo: UsersInfo[];
 }
 
 // 장소에 남긴 유저 정보
-export interface UserInfo {
+export interface UsersInfo {
   userId: number;
   profileImage: string;
   nickname: string;
   memo: string;
 }
 
+export interface PlaceListResponse {
+  totalCount: number;
+  placeInfos: PlaceInfos[];
+
+}
+
+export interface PlaceInfos {
+  place_id : number;
+  placeName: string;
+  address: string;
+  category: string;
+  lat: number,
+  lng: number,
+  favoriteCount: number,
+}

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -26,7 +26,7 @@ export interface PlaceListResponse {
 
 export interface PlaceInfos {
   place_id : number;
-  placeName: string;
+  name: string;
   address: string;
   category: string;
   lat: number,

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -25,11 +25,11 @@ export interface PlaceListResponse {
 }
 
 export interface PlaceInfos {
-  place_id : number;
+  placeId : number;
   name: string;
   address: string;
   category: string;
-  lat: number,
-  lng: number,
-  favoriteCount: number,
+  lat: number;
+  lng: number;
+  favoriteCount: number;
 }

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -33,3 +33,10 @@ export interface PlaceInfos {
   lng: number;
   favoriteCount: number;
 }
+
+export const PAGE = {
+  PLACELIST: "PLACELIST",
+  PLACEDETAIL: "PLACEDETAIL",
+} as const;
+
+export type PageType = (typeof PAGE)[keyof typeof PAGE];


### PR DESCRIPTION
## 📌 작업 개요
- 장소 리스트 컴포넌트와 상세 컴포넌트를 바꿔치기(?)하도록 수정, 즐겨찾기 리스트 API, 장소 상세 조회 API 연결

## ✨ 주요 변경 사항
- kakaoMap에 컴포넌트 종속되어있던 것 분리
- 실제 API 응답객체 생성
- API 연결(인근 즐겨찾기 장소 조회, 장소 클릭 시 메모리스트 조회 API)
- 장소 클릭 시 컴포넌트 교체


## 🖼️ 스크린샷 (선택)

https://github.com/user-attachments/assets/a976159e-2928-43c7-986d-8090b844d101


-> 클릭으로 왔다갔다 합니다 ㅠㅠ
-> api 연결 정상적으로 됩니다

## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
- 로컬환경에서 직접 구동했습니다.
- npm run build 통과했습니당



## 💬 기타 참고 사항
- 상단에 "서울시 > 강남구" 는 아직 하드코딩 데이터입니다. 마커 생성 기능 작업할 때 함께 작업하도록 하겠습니다.
close #62