### PR TITLE
UI/user-group-list 유저 그룹 리스트 UI, API 연결, Zustand 적용

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -7,6 +7,7 @@ import PlaceUserMemos from "@/components/map/PlaceUserMemos";
 import { useEffect, useState } from "react";
 import { fetchPlaceDetail, fetchPlaceList } from "@/lib/api/map";
 import { PAGE, PageType, PlaceDetailResponse, PlaceListResponse } from "@/types/map";
+import { UserGroupList } from "@/components/map/UserGroupList";
 
 const MapPage = () => {
 
@@ -16,6 +17,12 @@ const MapPage = () => {
   const [placeDetail, setPlaceDetail] = useState<PlaceDetailResponse | null>(
     null,
   );
+  const [groupModal, setGroupModal] = useState(false);
+
+  function handleClickGroupList() {
+    setGroupModal((prev) => !prev);
+  }
+
 
   function handleClick(placeId: number) {
     setPlaceId(placeId);
@@ -67,8 +74,11 @@ const MapPage = () => {
         <PlaceModal onClick={handleClick} placeList={placeList}></PlaceModal>
       )}
       {page == PAGE.PLACEDETAIL && placeDetail && (
-        <PlaceUserMemos backPage={backPage} placeDetail={placeDetail} />
+        <PlaceUserMemos openGroupList={handleClickGroupList} backPage={backPage} placeDetail={placeDetail} />
+
       )}
+
+      {groupModal && <UserGroupList />}
     </div>
   );
 };

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -6,14 +6,14 @@ import PlaceModal from "@/components/map/PlaceModal";
 import PlaceUserMemos from "@/components/map/PlaceUserMemos";
 import { useEffect, useState } from "react";
 import { fetchPlaceDetail, fetchPlaceList } from "@/lib/api/map";
-import { PAGE, PageType, PlaceDetailResponse, PlaceListResponse } from "@/types/map";
+import { PAGE, PlaceDetailResponse, PlaceListResponse } from "@/types/map";
 import { UserGroupList } from "@/components/map/UserGroupList";
+import { useMapStore } from "@/stores/mapStore";
 
 const MapPage = () => {
+  const { page, placeId, placeList } = useMapStore((state) => state);
+  const { setPlaceList } = useMapStore();
 
-  const [page, setPage] = useState<PageType>(PAGE.PLACELIST);
-  const [placeList, setPlaceList] = useState<PlaceListResponse | null>(null);
-  const [placeId, setPlaceId] = useState<number | null>(null);
   const [placeDetail, setPlaceDetail] = useState<PlaceDetailResponse | null>(
     null,
   );
@@ -21,16 +21,6 @@ const MapPage = () => {
 
   function handleClickGroupList() {
     setGroupModal((prev) => !prev);
-  }
-
-
-  function handleClick(placeId: number) {
-    setPlaceId(placeId);
-    setPage(PAGE.PLACEDETAIL);
-  }
-
-  function backPage() {
-    setPage(PAGE.PLACELIST);
   }
 
   useEffect(() => {
@@ -71,11 +61,13 @@ const MapPage = () => {
       <SideMenu />
 
       {page === PAGE.PLACELIST && placeList && (
-        <PlaceModal onClick={handleClick} placeList={placeList}></PlaceModal>
+        <PlaceModal placeList={placeList}></PlaceModal>
       )}
       {page == PAGE.PLACEDETAIL && placeDetail && (
-        <PlaceUserMemos openGroupList={handleClickGroupList} backPage={backPage} placeDetail={placeDetail} />
-
+        <PlaceUserMemos
+          openGroupList={handleClickGroupList}
+          placeDetail={placeDetail}
+        />
       )}
 
       {groupModal && <UserGroupList />}

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -9,7 +9,7 @@ import { UserGroupList } from "@/components/map/UserGroupList";
 import { useMapStore } from "@/stores/mapStore";
 
 const MapPage = () => {
-  const { page, groupModal } = useMapStore((state) => state);
+  const { page } = useMapStore((state) => state);
 
   return (
     <div>
@@ -18,8 +18,7 @@ const MapPage = () => {
 
       {page === PAGE.PLACELIST && <PlaceModal />}
       {page === PAGE.PLACEDETAIL && <PlaceUserMemos />}
-
-      {groupModal && <UserGroupList />}
+      {page === PAGE.USERGROUPLIST && <UserGroupList />}
     </div>
   );
 };

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -5,33 +5,16 @@ import SideMenu from "@/components/map/SideMenu";
 import PlaceModal from "@/components/map/PlaceModal";
 import PlaceUserMemos from "@/components/map/PlaceUserMemos";
 import { useEffect } from "react";
-import { fetchPlaceDetail, fetchPlaceList } from "@/lib/api/map";
-import { PAGE, PlaceListResponse } from "@/types/map";
+import { fetchPlaceDetail } from "@/lib/api/map";
+import { PAGE } from "@/types/map";
 import { UserGroupList } from "@/components/map/UserGroupList";
 import { useMapStore } from "@/stores/mapStore";
 
 const MapPage = () => {
   const { page, placeId, placeList, placeDetail, groupModal } = useMapStore((state) => state);
-  const { setPlaceList, setPlaceDetail } = useMapStore();
+  const { setPlaceDetail } = useMapStore();
 
-  useEffect(() => {
-    const lat = 37.554722;
-    const lng = 126.97083;
-    const distanceKm = 5;
 
-    (async () => {
-      try {
-        const data: PlaceListResponse = await fetchPlaceList(
-          lat,
-          lng,
-          distanceKm,
-        );
-        setPlaceList(data);
-      } catch (error) {
-        console.error("장소 목록을 불러오는 데 실패했습니다.", error);
-      }
-    })();
-  }, []);
 
   useEffect(() => {
     if (placeId !== null) {
@@ -52,7 +35,7 @@ const MapPage = () => {
       <SideMenu />
 
       {page === PAGE.PLACELIST && placeList && (
-        <PlaceModal placeList={placeList}></PlaceModal>
+        <PlaceModal />
       )}
       {page == PAGE.PLACEDETAIL && placeDetail && (
         <PlaceUserMemos

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -4,20 +4,15 @@ import KakaoMap from "@/components/map/KakaoMap";
 import SideMenu from "@/components/map/SideMenu";
 import PlaceModal from "@/components/map/PlaceModal";
 import PlaceUserMemos from "@/components/map/PlaceUserMemos";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { fetchPlaceDetail, fetchPlaceList } from "@/lib/api/map";
 import { PAGE, PlaceListResponse } from "@/types/map";
 import { UserGroupList } from "@/components/map/UserGroupList";
 import { useMapStore } from "@/stores/mapStore";
 
 const MapPage = () => {
-  const { page, placeId, placeList, placeDetail } = useMapStore((state) => state);
+  const { page, placeId, placeList, placeDetail, groupModal } = useMapStore((state) => state);
   const { setPlaceList, setPlaceDetail } = useMapStore();
-  const [groupModal, setGroupModal] = useState(false);
-
-  function handleClickGroupList() {
-    setGroupModal((prev) => !prev);
-  }
 
   useEffect(() => {
     const lat = 37.554722;
@@ -61,7 +56,6 @@ const MapPage = () => {
       )}
       {page == PAGE.PLACEDETAIL && placeDetail && (
         <PlaceUserMemos
-          openGroupList={handleClickGroupList}
           placeDetail={placeDetail}
         />
       )}

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -4,44 +4,20 @@ import KakaoMap from "@/components/map/KakaoMap";
 import SideMenu from "@/components/map/SideMenu";
 import PlaceModal from "@/components/map/PlaceModal";
 import PlaceUserMemos from "@/components/map/PlaceUserMemos";
-import { useEffect } from "react";
-import { fetchPlaceDetail } from "@/lib/api/map";
 import { PAGE } from "@/types/map";
 import { UserGroupList } from "@/components/map/UserGroupList";
 import { useMapStore } from "@/stores/mapStore";
 
 const MapPage = () => {
-  const { page, placeId, placeList, placeDetail, groupModal } = useMapStore((state) => state);
-  const { setPlaceDetail } = useMapStore();
-
-
-
-  useEffect(() => {
-    if (placeId !== null) {
-      (async () => {
-        try {
-          const data = await fetchPlaceDetail(placeId);
-          setPlaceDetail(data);
-        } catch (error) {
-          console.error("장소 상세 정보를 불러오는 데 실패했습니다.", error);
-        }
-      })();
-    }
-  }, [placeId]);
+  const { page, groupModal } = useMapStore((state) => state);
 
   return (
     <div>
       <KakaoMap />
       <SideMenu />
 
-      {page === PAGE.PLACELIST && placeList && (
-        <PlaceModal />
-      )}
-      {page == PAGE.PLACEDETAIL && placeDetail && (
-        <PlaceUserMemos
-          placeDetail={placeDetail}
-        />
-      )}
+      {page === PAGE.PLACELIST && <PlaceModal />}
+      {page === PAGE.PLACEDETAIL && <PlaceUserMemos />}
 
       {groupModal && <UserGroupList />}
     </div>

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -6,17 +6,13 @@ import PlaceModal from "@/components/map/PlaceModal";
 import PlaceUserMemos from "@/components/map/PlaceUserMemos";
 import { useEffect, useState } from "react";
 import { fetchPlaceDetail, fetchPlaceList } from "@/lib/api/map";
-import { PAGE, PlaceDetailResponse, PlaceListResponse } from "@/types/map";
+import { PAGE, PlaceListResponse } from "@/types/map";
 import { UserGroupList } from "@/components/map/UserGroupList";
 import { useMapStore } from "@/stores/mapStore";
 
 const MapPage = () => {
-  const { page, placeId, placeList } = useMapStore((state) => state);
-  const { setPlaceList } = useMapStore();
-
-  const [placeDetail, setPlaceDetail] = useState<PlaceDetailResponse | null>(
-    null,
-  );
+  const { page, placeId, placeList, placeDetail } = useMapStore((state) => state);
+  const { setPlaceList, setPlaceDetail } = useMapStore();
   const [groupModal, setGroupModal] = useState(false);
 
   function handleClickGroupList() {

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -15,6 +15,7 @@ export const Footer = () => {
     "/policy/terms",
     "/policy/privacy",
     "/editor",
+    "/map",
   ];
 
   if (hideFooterRoutes.includes(pathname)) return null;

--- a/src/components/map/BookmarkInfo.tsx
+++ b/src/components/map/BookmarkInfo.tsx
@@ -40,7 +40,7 @@ export function BookmarkInfo({ placeDetail }: BookmarkInfoProps) {
             </button>
             <span>
               {" "}
-              님 외 {placeDetail?.favoriteCount} 명이 즐겨찾기에 추가했습니다.
+              님 외 {placeDetail?.favoriteCount - 1} 명이 즐겨찾기에 추가했습니다.
             </span>
           </div>
         </>

--- a/src/components/map/PlaceCard.tsx
+++ b/src/components/map/PlaceCard.tsx
@@ -14,7 +14,7 @@ interface PlaceCardProps {
   address: string;
   category: string;
   favoriteCount: number;
-  onClick?: () => void; // 클릭 시 동작할 함수
+  onClick?: () => void;
 }
 
 const categoryIcons: Record<string, JSX.Element> = {

--- a/src/components/map/PlaceCard.tsx
+++ b/src/components/map/PlaceCard.tsx
@@ -6,6 +6,7 @@ import {
   Market,
 } from "@/components/common/Icons/category";
 import { JSX } from "react";
+import { useMapStore } from "@/stores/mapStore";
 
 interface PlaceCardProps {
   placeId: number;
@@ -30,12 +31,13 @@ export default function PlaceCard({
   address,
   category,
   favoriteCount,
-  onClick,
 }: PlaceCardProps) {
+  const { setPagePlaceDetail } = useMapStore();
+
   return (
     <li
       className="flex items-center hover:bg-gray-100 transition p-1"
-      onClick={onClick}
+      onClick={() => setPagePlaceDetail(placeId)}
       key={placeId}
     >
       {/* 이미지 영역 */}

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -1,12 +1,32 @@
-import React from "react";
+import React, { useEffect } from "react";
 import PlaceCard from "@/components/map/PlaceCard";
 import { PlaceListResponse } from "@/types/map";
+import { fetchPlaceList } from "@/lib/api/map";
+import { useMapStore } from "@/stores/mapStore";
 
-interface PlaceModalProps {
-  placeList: PlaceListResponse;
-}
+export default function PlaceModal() {
+  const placeList = useMapStore((state) => state.placeList);
+  const { setPlaceList } = useMapStore();
 
-export default function PlaceModal({ placeList }: PlaceModalProps) {
+  useEffect(() => {
+    const lat = 37.554722;
+    const lng = 126.97083;
+    const distanceKm = 5;
+
+    (async () => {
+      try {
+        const data: PlaceListResponse = await fetchPlaceList(
+          lat,
+          lng,
+          distanceKm,
+        );
+        setPlaceList(data);
+      } catch (error) {
+        console.error("장소 목록을 불러오는 데 실패했습니다.", error);
+      }
+    })();
+  }, []);
+
   return (
     <div className="flex flex-col absolute -bottom-4 left-4 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
       {/* 헤더 */}

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -4,10 +4,9 @@ import { PlaceListResponse } from "@/types/map";
 
 interface PlaceModalProps {
   placeList: PlaceListResponse;
-  onClick: (placeId: number) => void;
 }
 
-export default function PlaceModal({ placeList, onClick }: PlaceModalProps) {
+export default function PlaceModal({ placeList }: PlaceModalProps) {
   return (
     <div className="flex flex-col absolute -bottom-4 left-4 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
       {/* 헤더 */}
@@ -30,7 +29,6 @@ export default function PlaceModal({ placeList, onClick }: PlaceModalProps) {
             placeName={place.name}
             address={place.address}
             favoriteCount={place.favoriteCount}
-            onClick={() => onClick(place.placeId)}
           />
         ))}
       </ul>

--- a/src/components/map/PlaceUserMemos.tsx
+++ b/src/components/map/PlaceUserMemos.tsx
@@ -7,11 +7,13 @@ import { UserMemoCards } from "@/components/map/UserMemoCards";
 interface PlaceUserMemosProps {
   placeDetail: PlaceDetailResponse;
   backPage: () => void;
+  openGroupList?: () => void;
 }
 
 export default function PlaceUserMemos({
   placeDetail,
   backPage,
+  openGroupList,
 }: PlaceUserMemosProps) {
   return (
     <div className="flex flex-col absolute -bottom-4 left-4 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
@@ -20,7 +22,7 @@ export default function PlaceUserMemos({
       {/* 즐겨찾기 정보 */}
       <BookmarkInfo placeDetail={placeDetail} />
       {/* 유저 메모 리스트 */}
-      <UserMemoCards placeDetail={placeDetail} />
+      <UserMemoCards openGroupList={openGroupList} placeDetail={placeDetail} />
     </div>
   );
 }

--- a/src/components/map/PlaceUserMemos.tsx
+++ b/src/components/map/PlaceUserMemos.tsx
@@ -1,24 +1,36 @@
-import React from "react";
-import { PlaceDetailResponse } from "@/types/map";
+import React, { useEffect } from "react";
 import PlaceUserMemosHeader from "@/components/map/PlaceUserMemosHeader";
 import { BookmarkInfo } from "@/components/map/BookmarkInfo";
 import { UserMemoCards } from "@/components/map/UserMemoCards";
+import { fetchPlaceDetail } from "@/lib/api/map";
+import { useMapStore } from "@/stores/mapStore";
 
-interface PlaceUserMemosProps {
-  placeDetail: PlaceDetailResponse;
-}
+export default function PlaceUserMemos() {
+  const { placeId, placeDetail } = useMapStore((state) => state);
+  const { setPlaceDetail } = useMapStore();
 
-export default function PlaceUserMemos({
-  placeDetail,
-}: PlaceUserMemosProps) {
+  useEffect(() => {
+    if (placeId !== null) {
+      (async () => {
+        try {
+          const data = await fetchPlaceDetail(placeId);
+          setPlaceDetail(data);
+        } catch (error) {
+          console.error("장소 상세 정보를 불러오는 데 실패했습니다.", error);
+        }
+      })();
+    }
+  }, [placeId]);
+
   return (
     <div className="flex flex-col absolute -bottom-4 left-4 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
-      {/* 헤더 */}
-      <PlaceUserMemosHeader placeDetail={placeDetail} />
-      {/* 즐겨찾기 정보 */}
-      <BookmarkInfo placeDetail={placeDetail} />
-      {/* 유저 메모 리스트 */}
-      <UserMemoCards placeDetail={placeDetail} />
+      {placeDetail && (
+        <>
+          <PlaceUserMemosHeader placeDetail={placeDetail} />
+          <BookmarkInfo placeDetail={placeDetail} />
+          <UserMemoCards placeDetail={placeDetail} />
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/map/PlaceUserMemos.tsx
+++ b/src/components/map/PlaceUserMemos.tsx
@@ -6,12 +6,10 @@ import { UserMemoCards } from "@/components/map/UserMemoCards";
 
 interface PlaceUserMemosProps {
   placeDetail: PlaceDetailResponse;
-  openGroupList?: () => void;
 }
 
 export default function PlaceUserMemos({
   placeDetail,
-  openGroupList,
 }: PlaceUserMemosProps) {
   return (
     <div className="flex flex-col absolute -bottom-4 left-4 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
@@ -20,7 +18,7 @@ export default function PlaceUserMemos({
       {/* 즐겨찾기 정보 */}
       <BookmarkInfo placeDetail={placeDetail} />
       {/* 유저 메모 리스트 */}
-      <UserMemoCards openGroupList={openGroupList} placeDetail={placeDetail} />
+      <UserMemoCards placeDetail={placeDetail} />
     </div>
   );
 }

--- a/src/components/map/PlaceUserMemos.tsx
+++ b/src/components/map/PlaceUserMemos.tsx
@@ -6,19 +6,17 @@ import { UserMemoCards } from "@/components/map/UserMemoCards";
 
 interface PlaceUserMemosProps {
   placeDetail: PlaceDetailResponse;
-  backPage: () => void;
   openGroupList?: () => void;
 }
 
 export default function PlaceUserMemos({
   placeDetail,
-  backPage,
   openGroupList,
 }: PlaceUserMemosProps) {
   return (
     <div className="flex flex-col absolute -bottom-4 left-4 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
       {/* 헤더 */}
-      <PlaceUserMemosHeader placeDetail={placeDetail} backPage={backPage} />
+      <PlaceUserMemosHeader placeDetail={placeDetail} />
       {/* 즐겨찾기 정보 */}
       <BookmarkInfo placeDetail={placeDetail} />
       {/* 유저 메모 리스트 */}

--- a/src/components/map/PlaceUserMemosHeader.tsx
+++ b/src/components/map/PlaceUserMemosHeader.tsx
@@ -1,16 +1,17 @@
 import { ArrowLeftIcon, LucideStar, MoreVerticalIcon } from "lucide-react";
 import React, { useState } from "react";
 import { PlaceDetailResponse } from "@/types/map";
+import { useMapStore } from "@/stores/mapStore";
 
 interface PlaceUserMemosHeaderProps {
-  backPage: () => void;
   placeDetail: PlaceDetailResponse;
 }
 
 export default function PlaceUserMemosHeader({
-  backPage,
   placeDetail,
 }: PlaceUserMemosHeaderProps) {
+  const { setPagePlaceList } = useMapStore();
+
   const [favorite, setFavorite] = useState(false);
 
   function handleClickFavorite() {
@@ -20,7 +21,7 @@ export default function PlaceUserMemosHeader({
   return (
     <div className="relative w-full px-4 py-4">
       <div className="flex flex-col items-center justify-center">
-        <button className="absolute left-4 top-4" onClick={backPage}>
+        <button className="absolute left-4 top-4" onClick={setPagePlaceList}>
           <ArrowLeftIcon />
         </button>
 

--- a/src/components/map/SideMenu.tsx
+++ b/src/components/map/SideMenu.tsx
@@ -20,14 +20,14 @@ export default function SideMenu() {
       }`}
     >
       <ul className="flex flex-col items-center justify-center space-y-6 w-full h-full">
-        {/*  메뉴 토글 버튼 (LogoIcon) */}
+        {/*  메뉴 토글 버튼 */}
         <li onClick={() => setOpenModal(!openModal)} className="cursor-pointer">
           <LogoIcon className="w-16 h-16" />
         </li>
 
         {openModal && (
           <>
-            {/* 🔽 회색 구분선 */}
+            {/* 회색 구분선 */}
             <li className="w-3/4 border-t border-gray-300 my-2" />
 
             <Link href="/">

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -1,11 +1,26 @@
 import { MoreVertical, Star } from "lucide-react";
 import { DefaultProfileIcon } from "@/components/common/Icons";
+import { useEffect } from "react";
+import { GroupListResponseList } from "@/types/map";
+import { fetchGroupList } from "@/lib/api/map";
+import { useAuthStore } from "@/stores/useAuthStore";
+import { useMapStore } from "@/stores/mapStore";
 
 export function UserGroupList() {
+  const userId = useAuthStore((state) => state.user?.userId);
+  const groupList = useMapStore((state) => state.groupList);
+  const { setGroupList } = useMapStore();
 
-
-
-
+  useEffect(() => {
+    (async () => {
+      try {
+        const data: GroupListResponseList = await fetchGroupList(userId);
+        setGroupList(data);
+      } catch (error) {
+        console.error("유저의 그룹 리스트를 불러오는 데 실패했습니다.", error);
+      }
+    })();
+  }, []);
 
   return (
     <>
@@ -23,33 +38,35 @@ export function UserGroupList() {
         </div>
 
         <ul className="flex-1 overflow-y-auto divide-y">
-          {[
-            { name: "강남 나만 갈꺼야 맛집", count: 4 },
-            { name: "갈꺼야 카페", count: 25 },
-            { name: "집근처 공부 카페", count: 3 },
-          ].map((group, idx) => (
-            <li
-              key={idx}
-              className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
-            >
-              <div className="flex items-center gap-3">
-                <div className="w-8 h-8 rounded-full bg-violet-100 flex items-center justify-center">
-                  <Star size={16} className="text-violet-500" />
-                </div>
-                <div>
-                  <div className="font-medium text-sm text-gray-900">
-                    {group.name}
+          {groupList && groupList.length > 0 ? (
+            groupList.map((group, idx) => (
+              <li
+                key={idx}
+                className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="w-8 h-8 rounded-full bg-violet-100 flex items-center justify-center">
+                    <Star size={16} className="text-violet-500" />
                   </div>
-                  <div className="text-xs text-gray-500">
-                    장소 {group.count}
+                  <div>
+                    <div className="font-medium text-sm text-gray-900">
+                      {group.name}
+                    </div>
+                    <div className="text-xs text-gray600">
+                      장소 {groupList.length}
+                    </div>
                   </div>
                 </div>
-              </div>
-              <button className="hover:bg-gray200 rounded-full">
-                <MoreVertical size={20} className="text-gray-400" />
-              </button>
-            </li>
-          ))}
+                <button className="hover:bg-gray200 rounded-full">
+                  <MoreVertical size={20} className="text-gray-400" />
+                </button>
+              </li>
+            ))
+          ) : (
+            <div className="text-sm text-gray600 text-center py-10">
+              등록된 그룹이 없습니다.
+            </div>
+          )}
         </ul>
       </div>
     </>

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -2,6 +2,11 @@ import { MoreVertical, Star } from "lucide-react";
 import { DefaultProfileIcon } from "@/components/common/Icons";
 
 export function UserGroupList() {
+
+
+
+
+
   return (
     <>
       <div className="w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-4 bottom-[-1rem] z-10 flex flex-col">

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -61,7 +61,7 @@ export function UserGroupList() {
                       </div>
                       <div className="text-xs text-gray-600">
                         {/* 여기 응답 객체 백엔드단 코드 추가 되면 수정해야함!!!!!!!!!!!1*/}
-                        장소 {22}
+                        장소 {group.groupFavoriteCount ?? 0}
                       </div>
                     </div>
                   </div>

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -4,28 +4,23 @@ import { useEffect } from "react";
 import { GroupListResponseList, PAGE } from "@/types/map";
 import { fetchGroupList } from "@/lib/api/map";
 import { useMapStore } from "@/stores/mapStore";
-import { useAuthStore } from "@/stores/useAuthStore";
+import { useProfile } from "@/hooks/useProfile";
 
 export function UserGroupList() {
-  const userId = useAuthStore((state) => state.user?.userId);
-  const { groupList, placeId, page } = useMapStore((state) => state);
+  const { groupList, placeId, page, otherUserId } = useMapStore((state) => state);
   const { setGroupList, setPagePlaceDetail } = useMapStore();
-  // const [otherUserId, setOtherUserId] = useState<number | undefined>(0);
+  const { data: profile } = useProfile(otherUserId);
 
   useEffect(() => {
     (async () => {
       try {
-        const data: GroupListResponseList = await fetchGroupList(5);
+        const data: GroupListResponseList = await fetchGroupList(otherUserId);
         setGroupList(data);
       } catch (error) {
         console.error("유저의 그룹 리스트를 불러오는 데 실패했습니다.", error);
       }
     })();
-  }, []);
-
-  useEffect(() => {
-    console.log("page:", page);
-  }, [page]);
+  }, [otherUserId]);
 
   return (
     <>
@@ -45,8 +40,8 @@ export function UserGroupList() {
 
           <div className="flex flex-col items-center py-4 border-b">
             <DefaultProfileIcon className="w-10 h-10 rounded-full object-cover" />
-            <span className="font-semibold text-lg mt-2">이브니</span>
-            <span className="text-sm text-gray-500">D+1187</span>
+            <span className="font-semibold text-lg mt-2">{profile?.nickname}</span>
+            <span className="text-sm text-gray-500">{profile?.liveAloneDate}</span>
           </div>
 
           <ul className="flex-1 overflow-y-auto divide-y">
@@ -65,7 +60,8 @@ export function UserGroupList() {
                         {group.name}
                       </div>
                       <div className="text-xs text-gray-600">
-                        장소 {groupList.length}
+                        {/* 여기 응답 객체 백엔드단 코드 추가 되면 수정해야함!!!!!!!!!!!1*/}
+                        장소 {22}
                       </div>
                     </div>
                   </div>

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -1,5 +1,5 @@
-import Image from "next/image";
 import { MoreVertical, Star } from "lucide-react";
+import { DefaultProfileIcon } from "@/components/common/Icons";
 
 export function UserGroupList() {
 
@@ -7,25 +7,19 @@ export function UserGroupList() {
   return (
     <>
       <div className="w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-4 bottom-[-1rem] z-10 flex flex-col">
-        {/* 위쪽 드래그 핸들 */}
+
         <div className="flex justify-center pt-2">
           <div className="w-10 h-1.5 bg-gray-300 rounded-full" />
         </div>
 
         {/* 유저 정보 */}
         <div className="flex flex-col items-center py-4 border-b">
-          <Image
-            src="/mock-profile.jpg" // 실제 프로필 이미지 URL
-            alt="프로필 이미지"
-            width={60}
-            height={60}
-            className="rounded-full"
-          />
+          <DefaultProfileIcon className="w-10 h-10 rounded-full object-cover" />
+
           <span className="font-semibold text-lg mt-2">이브니</span>
           <span className="text-sm text-gray-500">D+1187</span>
         </div>
 
-        {/* 그룹 리스트 */}
         <ul className="flex-1 overflow-y-auto divide-y">
           {[
             { name: "강남 나만 갈꺼야 맛집", count: 4 },

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -1,20 +1,21 @@
-import { MoreVertical, Star } from "lucide-react";
+import { ArrowLeft, MoreVertical, Star } from "lucide-react";
 import { DefaultProfileIcon } from "@/components/common/Icons";
 import { useEffect } from "react";
-import { GroupListResponseList } from "@/types/map";
+import { GroupListResponseList, PAGE } from "@/types/map";
 import { fetchGroupList } from "@/lib/api/map";
-import { useAuthStore } from "@/stores/useAuthStore";
 import { useMapStore } from "@/stores/mapStore";
+import { useAuthStore } from "@/stores/useAuthStore";
 
 export function UserGroupList() {
   const userId = useAuthStore((state) => state.user?.userId);
-  const groupList = useMapStore((state) => state.groupList);
-  const { setGroupList } = useMapStore();
+  const { groupList, placeId, page } = useMapStore((state) => state);
+  const { setGroupList, setPagePlaceDetail } = useMapStore();
+  // const [otherUserId, setOtherUserId] = useState<number | undefined>(0);
 
   useEffect(() => {
     (async () => {
       try {
-        const data: GroupListResponseList = await fetchGroupList(userId);
+        const data: GroupListResponseList = await fetchGroupList(5);
         setGroupList(data);
       } catch (error) {
         console.error("유저의 그룹 리스트를 불러오는 데 실패했습니다.", error);
@@ -22,53 +23,65 @@ export function UserGroupList() {
     })();
   }, []);
 
+  useEffect(() => {
+    console.log("page:", page);
+  }, [page]);
+
   return (
     <>
-      <div className="w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-4 bottom-[-1rem] z-10 flex flex-col">
-        <div className="flex justify-center pt-2">
-          <div className="w-10 h-1.5 bg-gray-300 rounded-full" />
-        </div>
+      {page === PAGE.USERGROUPLIST && (
+        <div className={`w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-4 bottom-[-1rem] z-10 flex flex-col`}>
+          <div className="flex items-center justify-between px-4 py-2 border-b">
+            {/* 뒤로 가기*/}
+            <button
+              onClick={() => setPagePlaceDetail(placeId)}
+              className="p-1 rounded-full hover:bg-gray-100"
+            >
+              <ArrowLeft size={20} className="text-gray-700" />
+            </button>
+            <div className="text-sm font-medium text-gray-600">그룹 목록</div>
+            <div className="w-6" />
+          </div>
 
-        {/* 유저 정보 */}
-        <div className="flex flex-col items-center py-4 border-b">
-          <DefaultProfileIcon className="w-10 h-10 rounded-full object-cover" />
+          <div className="flex flex-col items-center py-4 border-b">
+            <DefaultProfileIcon className="w-10 h-10 rounded-full object-cover" />
+            <span className="font-semibold text-lg mt-2">이브니</span>
+            <span className="text-sm text-gray-500">D+1187</span>
+          </div>
 
-          <span className="font-semibold text-lg mt-2">이브니</span>
-          <span className="text-sm text-gray-500">D+1187</span>
-        </div>
-
-        <ul className="flex-1 overflow-y-auto divide-y">
-          {groupList && groupList.length > 0 ? (
-            groupList.map((group, idx) => (
-              <li
-                key={idx}
-                className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-full bg-violet-100 flex items-center justify-center">
-                    <Star size={16} className="text-violet-500" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-sm text-gray-900">
-                      {group.name}
+          <ul className="flex-1 overflow-y-auto divide-y">
+            {groupList && groupList.length > 0 ? (
+              groupList.map((group, idx) => (
+                <li
+                  key={idx}
+                  className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-full bg-violet-100 flex items-center justify-center">
+                      <Star size={16} className="text-violet-500" />
                     </div>
-                    <div className="text-xs text-gray600">
-                      장소 {groupList.length}
+                    <div>
+                      <div className="font-medium text-sm text-gray-900">
+                        {group.name}
+                      </div>
+                      <div className="text-xs text-gray-600">
+                        장소 {groupList.length}
+                      </div>
                     </div>
                   </div>
-                </div>
-                <button className="hover:bg-gray200 rounded-full">
-                  <MoreVertical size={20} className="text-gray-400" />
-                </button>
-              </li>
-            ))
-          ) : (
-            <div className="text-sm text-gray600 text-center py-10">
-              등록된 그룹이 없습니다.
-            </div>
-          )}
-        </ul>
-      </div>
+                  <button className="hover:bg-gray-200 rounded-full p-1">
+                    <MoreVertical size={20} className="text-gray-400" />
+                  </button>
+                </li>
+              ))
+            ) : (
+              <div className="text-sm text-gray-600 text-center py-10">
+                등록된 그룹이 없습니다.
+              </div>
+            )}
+          </ul>
+        </div>
+      )}
     </>
   );
 }

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -1,10 +1,51 @@
+import Image from "next/image";
+import { MoreVertical, Star } from "lucide-react";
+
 export function UserGroupList() {
 
 
   return (
     <>
-      <div className="flex flex-col absolute -bottom-4 left-60 z-10 w-96 h-96 bg-red-400 rounded-t-2xl shadow-lg overflow-hidden">
-ddd
+      <div className="w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-4 bottom-[-1rem] z-10 flex flex-col">
+        {/* 위쪽 드래그 핸들 */}
+        <div className="flex justify-center pt-2">
+          <div className="w-10 h-1.5 bg-gray-300 rounded-full" />
+        </div>
+
+        {/* 유저 정보 */}
+        <div className="flex flex-col items-center py-4 border-b">
+          <Image
+            src="/mock-profile.jpg" // 실제 프로필 이미지 URL
+            alt="프로필 이미지"
+            width={60}
+            height={60}
+            className="rounded-full"
+          />
+          <span className="font-semibold text-lg mt-2">이브니</span>
+          <span className="text-sm text-gray-500">D+1187</span>
+        </div>
+
+        {/* 그룹 리스트 */}
+        <ul className="flex-1 overflow-y-auto divide-y">
+          {[
+            { name: "강남 나만 갈꺼야 맛집", count: 4 },
+            { name: "갈꺼야 카페", count: 25 },
+            { name: "집근처 공부 카페", count: 3 },
+          ].map((group, idx) => (
+            <li key={idx} className="flex items-center justify-between px-4 py-3 hover:bg-gray-50">
+              <div className="flex items-center gap-3">
+                <div className="w-8 h-8 rounded-full bg-violet-100 flex items-center justify-center">
+                  <Star size={16} className="text-violet-500" />
+                </div>
+                <div>
+                  <div className="font-medium text-sm text-gray-900">{group.name}</div>
+                  <div className="text-xs text-gray-500">장소 {group.count}</div>
+                </div>
+              </div>
+              <MoreVertical size={20} className="text-gray-400" />
+            </li>
+          ))}
+        </ul>
       </div>
     </>
   );

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -2,12 +2,9 @@ import { MoreVertical, Star } from "lucide-react";
 import { DefaultProfileIcon } from "@/components/common/Icons";
 
 export function UserGroupList() {
-
-
   return (
     <>
       <div className="w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-4 bottom-[-1rem] z-10 flex flex-col">
-
         <div className="flex justify-center pt-2">
           <div className="w-10 h-1.5 bg-gray-300 rounded-full" />
         </div>
@@ -26,17 +23,26 @@ export function UserGroupList() {
             { name: "갈꺼야 카페", count: 25 },
             { name: "집근처 공부 카페", count: 3 },
           ].map((group, idx) => (
-            <li key={idx} className="flex items-center justify-between px-4 py-3 hover:bg-gray-50">
+            <li
+              key={idx}
+              className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
+            >
               <div className="flex items-center gap-3">
                 <div className="w-8 h-8 rounded-full bg-violet-100 flex items-center justify-center">
                   <Star size={16} className="text-violet-500" />
                 </div>
                 <div>
-                  <div className="font-medium text-sm text-gray-900">{group.name}</div>
-                  <div className="text-xs text-gray-500">장소 {group.count}</div>
+                  <div className="font-medium text-sm text-gray-900">
+                    {group.name}
+                  </div>
+                  <div className="text-xs text-gray-500">
+                    장소 {group.count}
+                  </div>
                 </div>
               </div>
-              <MoreVertical size={20} className="text-gray-400" />
+              <button className="hover:bg-gray200 rounded-full">
+                <MoreVertical size={20} className="text-gray-400" />
+              </button>
             </li>
           ))}
         </ul>

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -1,0 +1,11 @@
+export function UserGroupList() {
+
+
+  return (
+    <>
+      <div className="flex flex-col absolute -bottom-4 left-60 z-10 w-96 h-96 bg-red-400 rounded-t-2xl shadow-lg overflow-hidden">
+ddd
+      </div>
+    </>
+  );
+}

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -14,8 +14,11 @@ export function UserGroupList() {
   useEffect(() => {
     (async () => {
       try {
-        const data: GroupListResponseList = await fetchGroupList(otherUserId);
-        setGroupList(data);
+        if (otherUserId != null) {
+          const data: GroupListResponseList = await fetchGroupList(otherUserId);
+          setGroupList(data);
+        }
+
       } catch (error) {
         console.error("유저의 그룹 리스트를 불러오는 데 실패했습니다.", error);
       }
@@ -29,7 +32,7 @@ export function UserGroupList() {
           <div className="flex items-center justify-between px-4 py-2 border-b">
             {/* 뒤로 가기*/}
             <button
-              onClick={() => setPagePlaceDetail(placeId)}
+              onClick={() => setPagePlaceDetail(placeId!)}
               className="p-1 rounded-full hover:bg-gray-100"
             >
               <ArrowLeft size={20} className="text-gray-700" />

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -5,6 +5,7 @@ import { GroupListResponseList, PAGE } from "@/types/map";
 import { fetchGroupList } from "@/lib/api/map";
 import { useMapStore } from "@/stores/mapStore";
 import { useProfile } from "@/hooks/useProfile";
+import FallbackMessage from "@/components/common/Fallback/FallbackMessage";
 
 export function UserGroupList() {
   const { groupList, placeId, page, otherUserId } = useMapStore((state) => state);
@@ -74,9 +75,12 @@ export function UserGroupList() {
                 </li>
               ))
             ) : (
-              <div className="text-sm text-gray-600 text-center py-10">
-                등록된 그룹이 없습니다.
-              </div>
+              <FallbackMessage
+                className="등록된 그룹이 없습니다."
+              />
+              // <div className="text-sm text-gray-600 text-center py-10">
+              //   등록된 그룹이 없습니다.
+              // </div>
             )}
           </ul>
         </div>

--- a/src/components/map/UserMemoCard.tsx
+++ b/src/components/map/UserMemoCard.tsx
@@ -4,12 +4,14 @@ import { useMapStore } from "@/stores/mapStore";
 import { useEffect } from "react";
 
 interface UserMemoProps {
+  userId: number;
   profileImage: string;
   nickName: string;
   memo: string;
 }
 
 export default function UserMemoCard({
+  userId,
   profileImage,
   nickName,
   memo,
@@ -17,10 +19,10 @@ export default function UserMemoCard({
   const page = useMapStore((state) => state.page);
   const { setPageGroupList } = useMapStore();
 
+
   useEffect(() => {
     console.log("page : ", page);
   }, [page]);
-
 
   return (
     <li className="flex items-center hover:bg-gray100 transition p-1">
@@ -36,7 +38,7 @@ export default function UserMemoCard({
       </button>
       <div className="items-center flex p-3 shadow-sm space-x-3">
         <button
-          onClick={() => setPageGroupList()}
+          onClick={() => setPageGroupList(userId)}
           className="font-bold text-base flex-shrink-0 text-left text-gray900 hover:underline focus:outline-none"
         >
           {nickName}

--- a/src/components/map/UserMemoCard.tsx
+++ b/src/components/map/UserMemoCard.tsx
@@ -1,21 +1,27 @@
 import Image from "next/image";
 import { getProfileImageUrl } from "@/utils/image";
-import { useState } from "react";
-import { UserGroupList } from "@/components/map/UserGroupList";
+import { useMapStore } from "@/stores/mapStore";
+import { useEffect } from "react";
 
 interface UserMemoProps {
   profileImage: string;
   nickName: string;
   memo: string;
-  openGroupList?: (() => void) | undefined;
 }
 
 export default function UserMemoCard({
   profileImage,
   nickName,
   memo,
-  openGroupList,
 }: UserMemoProps) {
+  const groupModal = useMapStore((state) => state.groupModal);
+  const { setGroupModal } = useMapStore();
+
+  useEffect(() => {
+    console.log("groupModal : ", groupModal);
+  }, [groupModal]);
+
+
   return (
     <li className="flex items-center hover:bg-gray100 transition p-1">
       {/* 이미지 영역 */}
@@ -30,7 +36,7 @@ export default function UserMemoCard({
       </button>
       <div className="items-center flex p-3 shadow-sm space-x-3">
         <button
-          onClick={openGroupList}
+          onClick={() => setGroupModal(groupModal)}
           className="font-bold text-base flex-shrink-0 text-left text-gray900 hover:underline focus:outline-none"
         >
           {nickName}

--- a/src/components/map/UserMemoCard.tsx
+++ b/src/components/map/UserMemoCard.tsx
@@ -1,16 +1,20 @@
 import Image from "next/image";
 import { getProfileImageUrl } from "@/utils/image";
+import { useState } from "react";
+import { UserGroupList } from "@/components/map/UserGroupList";
 
 interface UserMemoProps {
   profileImage: string;
   nickName: string;
   memo: string;
+  openGroupList?: (() => void) | undefined;
 }
 
 export default function UserMemoCard({
   profileImage,
   nickName,
   memo,
+  openGroupList,
 }: UserMemoProps) {
   return (
     <li className="flex items-center hover:bg-gray100 transition p-1">
@@ -25,7 +29,12 @@ export default function UserMemoCard({
         />
       </button>
       <div className="items-center flex p-3 shadow-sm space-x-3">
-        <span className="font-bold text-base flex-shrink-0">{nickName}</span>
+        <button
+          onClick={openGroupList}
+          className="font-bold text-base flex-shrink-0 text-left text-gray900 hover:underline focus:outline-none"
+        >
+          {nickName}
+        </button>
         <span className="text-gray600">{memo}</span>
       </div>
     </li>

--- a/src/components/map/UserMemoCard.tsx
+++ b/src/components/map/UserMemoCard.tsx
@@ -14,12 +14,12 @@ export default function UserMemoCard({
   nickName,
   memo,
 }: UserMemoProps) {
-  const groupModal = useMapStore((state) => state.groupModal);
-  const { setGroupModal } = useMapStore();
+  const page = useMapStore((state) => state.page);
+  const { setPageGroupList } = useMapStore();
 
   useEffect(() => {
-    console.log("groupModal : ", groupModal);
-  }, [groupModal]);
+    console.log("page : ", page);
+  }, [page]);
 
 
   return (
@@ -36,7 +36,7 @@ export default function UserMemoCard({
       </button>
       <div className="items-center flex p-3 shadow-sm space-x-3">
         <button
-          onClick={() => setGroupModal(groupModal)}
+          onClick={() => setPageGroupList()}
           className="font-bold text-base flex-shrink-0 text-left text-gray900 hover:underline focus:outline-none"
         >
           {nickName}

--- a/src/components/map/UserMemoCards.tsx
+++ b/src/components/map/UserMemoCards.tsx
@@ -4,9 +4,13 @@ import { PlaceDetailResponse } from "@/types/map";
 
 interface UserMemoCardsProps {
   placeDetail: PlaceDetailResponse;
+  openGroupList?: (() => void) | undefined;
 }
 
-export function UserMemoCards({ placeDetail }: UserMemoCardsProps) {
+export function UserMemoCards({
+  placeDetail,
+  openGroupList,
+}: UserMemoCardsProps) {
   return (
     <ul className="flex flex-col gap-3 px-4 py-4 overflow-y-auto">
       {placeDetail?.usersInfo.map((user) => (
@@ -15,6 +19,7 @@ export function UserMemoCards({ placeDetail }: UserMemoCardsProps) {
           profileImage={user.profileImage}
           nickName={user.nickname}
           memo={user.memo}
+          openGroupList={openGroupList}
         />
       ))}
     </ul>

--- a/src/components/map/UserMemoCards.tsx
+++ b/src/components/map/UserMemoCards.tsx
@@ -4,13 +4,10 @@ import { PlaceDetailResponse } from "@/types/map";
 
 interface UserMemoCardsProps {
   placeDetail: PlaceDetailResponse;
-  openGroupList?: (() => void) | undefined;
 }
 
-export function UserMemoCards({
-  placeDetail,
-  openGroupList,
-}: UserMemoCardsProps) {
+export function UserMemoCards({ placeDetail }: UserMemoCardsProps) {
+
   return (
     <ul className="flex flex-col gap-3 px-4 py-4 overflow-y-auto">
       {placeDetail?.usersInfo.map((user) => (
@@ -19,7 +16,6 @@ export function UserMemoCards({
           profileImage={user.profileImage}
           nickName={user.nickname}
           memo={user.memo}
-          openGroupList={openGroupList}
         />
       ))}
     </ul>

--- a/src/components/map/UserMemoCards.tsx
+++ b/src/components/map/UserMemoCards.tsx
@@ -13,6 +13,7 @@ export function UserMemoCards({ placeDetail }: UserMemoCardsProps) {
       {placeDetail?.usersInfo.map((user) => (
         <UserMemoCard
           key={user.userId}
+          userId={user.userId}
           profileImage={user.profileImage}
           nickName={user.nickname}
           memo={user.memo}

--- a/src/lib/api/map.ts
+++ b/src/lib/api/map.ts
@@ -19,8 +19,8 @@ export const fetchPlaceDetail = async (placeId: number): Promise<PlaceDetailResp
   });
 };
 
-export const fetchGroupList = async (userId: number): Promise<GroupListResponse> => {
-  return await client<GroupListResponse>(`/api/group/user/${userId}/group`, {
+export const fetchGroupList = async (userId: number): Promise<GroupListResponse[]> => {
+  return await client<GroupListResponse[]>(`/api/group/user/${userId}/group`, {
     method: "GET",
   })
 }

--- a/src/lib/api/map.ts
+++ b/src/lib/api/map.ts
@@ -20,7 +20,7 @@ export const fetchPlaceDetail = async (placeId: number): Promise<PlaceDetailResp
 };
 
 export const fetchGroupList = async (userId: number): Promise<GroupListResponse[]> => {
-  return await client<GroupListResponse[]>(`/api/group/user/${userId}/group`, {
+  return await client<GroupListResponse[]>(`/group/user/${userId}/group`, {
     method: "GET",
   })
 }

--- a/src/lib/api/map.ts
+++ b/src/lib/api/map.ts
@@ -1,5 +1,5 @@
 import { client } from "@/lib/fetch/client";
-import { PlaceListResponse, PlaceDetailResponse } from "@/types/map";
+import { PlaceListResponse, PlaceDetailResponse, GroupListResponse } from "@/types/map";
 
 // lat, lng, distanceKm을 파라미터로 받아 사용
 export const fetchPlaceList = async (
@@ -18,3 +18,9 @@ export const fetchPlaceDetail = async (placeId: number): Promise<PlaceDetailResp
     method: "GET",
   });
 };
+
+export const fetchGroupList = async (userId: number): Promise<GroupListResponse> => {
+  return await client<GroupListResponse>(`/api/group/user/${userId}/group`, {
+    method: "GET",
+  })
+}

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+import { PAGE, PageType, PlaceDetailResponse, PlaceListResponse } from "@/types/map";
+
+type MapStore = {
+  page: PageType;
+  placeList: PlaceListResponse | null;
+  placeId: number | null;
+  placeDetail: PlaceDetailResponse | null;
+  groupModal: boolean;
+  setPagePlaceList: () => void;
+  setPagePlaceDetail: (placeDetail: PlaceDetailResponse) => void;
+};
+
+export const useMapStore = create<MapStore>((set) => ({
+  // 초기값
+  page: PAGE.PLACELIST,
+  placeList: null,
+  placeId: null,
+  placeDetail: null,
+  groupModal: false,
+
+  setPagePlaceList: () =>
+    set(() => ({
+      page: PAGE.PLACELIST,
+    })),
+  setPagePlaceDetail: () =>
+    set(() => ({
+      page: PAGE.PLACEDETAIL,
+    })),
+
+}));

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import {
+  GroupListResponse,
   PAGE,
   PageType,
   PlaceDetailResponse,
@@ -11,12 +12,14 @@ type MapStore = {
   placeList: PlaceListResponse | null;
   placeId: number | null;
   placeDetail: PlaceDetailResponse | null;
+  groupList: GroupListResponse | null;
   groupModal: boolean;
   setPagePlaceList: () => void;
   setPagePlaceDetail: (placeId: number) => void;
   setPlaceList: (placeList: PlaceListResponse) => void;
   setPlaceDetail: (placeDetail: PlaceDetailResponse) => void;
   setGroupModal: (groupModal: boolean) => void;
+  setGroupList: (groupList: GroupListResponse) => void;
 };
 
 export const useMapStore = create<MapStore>((set) => ({
@@ -26,6 +29,7 @@ export const useMapStore = create<MapStore>((set) => ({
   placeId: null,
   placeDetail: null,
   groupModal: false,
+  groupList: null,
 
   setPagePlaceList: () =>
     set(() => ({
@@ -47,5 +51,9 @@ export const useMapStore = create<MapStore>((set) => ({
   setGroupModal: (groupModal: boolean) =>
     set(() => ({
       groupModal: !groupModal,
+    })),
+  setGroupList: (groupList: GroupListResponse) =>
+    set(() => ({
+      groupList: groupList,
     })),
 }));

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -13,9 +13,10 @@ type MapStore = {
   placeId: number | null;
   placeDetail: PlaceDetailResponse | null;
   groupList: GroupListResponse[] | null;
+  otherUserId: number | null;
   setPagePlaceList: () => void;
   setPagePlaceDetail: (placeId: number) => void;
-  setPageGroupList:() => void;
+  setPageGroupList:(otherUserId: number) => void;
   setPlaceList: (placeList: PlaceListResponse) => void;
   setPlaceDetail: (placeDetail: PlaceDetailResponse) => void;
   setGroupList: (groupList: GroupListResponse[]) => void;
@@ -28,6 +29,8 @@ export const useMapStore = create<MapStore>((set) => ({
   placeId: null,
   placeDetail: null,
   groupList: [],
+  otherUserId: null,
+
 
   setPagePlaceList: () =>
     set(() => ({
@@ -38,9 +41,10 @@ export const useMapStore = create<MapStore>((set) => ({
       page: PAGE.PLACEDETAIL,
       placeId: placeId,
     })),
-  setPageGroupList:() =>
+  setPageGroupList:(otherUserId: number) =>
     set(() => ({
       page: PAGE.USERGROUPLIST,
+      otherUserId: otherUserId,
     })),
   setPlaceList: (placeList: PlaceListResponse) =>
     set(() => ({

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
-import { PAGE, PageType, PlaceDetailResponse, PlaceListResponse } from "@/types/map";
+import {
+  PAGE,
+  PageType,
+  PlaceDetailResponse,
+  PlaceListResponse,
+} from "@/types/map";
 
 type MapStore = {
   page: PageType;
@@ -8,7 +13,8 @@ type MapStore = {
   placeDetail: PlaceDetailResponse | null;
   groupModal: boolean;
   setPagePlaceList: () => void;
-  setPagePlaceDetail: (placeDetail: PlaceDetailResponse) => void;
+  setPagePlaceDetail: (placeId: number) => void;
+  setPlaceList: (placeList: PlaceListResponse) => void;
 };
 
 export const useMapStore = create<MapStore>((set) => ({
@@ -23,9 +29,13 @@ export const useMapStore = create<MapStore>((set) => ({
     set(() => ({
       page: PAGE.PLACELIST,
     })),
-  setPagePlaceDetail: () =>
+  setPagePlaceDetail: (placeId: number) =>
     set(() => ({
       page: PAGE.PLACEDETAIL,
+      placeId: placeId,
     })),
-
+  setPlaceList: (placeList: PlaceListResponse) =>
+    set(() => ({
+      placeList: placeList,
+    }))
 }));

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -15,7 +15,8 @@ type MapStore = {
   setPagePlaceList: () => void;
   setPagePlaceDetail: (placeId: number) => void;
   setPlaceList: (placeList: PlaceListResponse) => void;
-  setPlaceDetail :(placeDetail: PlaceDetailResponse) => void;
+  setPlaceDetail: (placeDetail: PlaceDetailResponse) => void;
+  setGroupModal: (groupModal: boolean) => void;
 };
 
 export const useMapStore = create<MapStore>((set) => ({
@@ -39,8 +40,12 @@ export const useMapStore = create<MapStore>((set) => ({
     set(() => ({
       placeList: placeList,
     })),
-  setPlaceDetail: (placeDetail : PlaceDetailResponse) =>
+  setPlaceDetail: (placeDetail: PlaceDetailResponse) =>
     set(() => ({
       placeDetail: placeDetail,
-    }))
+    })),
+  setGroupModal: (groupModal: boolean) =>
+    set(() => ({
+      groupModal: !groupModal,
+    })),
 }));

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -13,12 +13,11 @@ type MapStore = {
   placeId: number | null;
   placeDetail: PlaceDetailResponse | null;
   groupList: GroupListResponse[] | null;
-  groupModal: boolean;
   setPagePlaceList: () => void;
   setPagePlaceDetail: (placeId: number) => void;
+  setPageGroupList:() => void;
   setPlaceList: (placeList: PlaceListResponse) => void;
   setPlaceDetail: (placeDetail: PlaceDetailResponse) => void;
-  setGroupModal: (groupModal: boolean) => void;
   setGroupList: (groupList: GroupListResponse[]) => void;
 };
 
@@ -28,7 +27,6 @@ export const useMapStore = create<MapStore>((set) => ({
   placeList: null,
   placeId: null,
   placeDetail: null,
-  groupModal: false,
   groupList: [],
 
   setPagePlaceList: () =>
@@ -40,6 +38,10 @@ export const useMapStore = create<MapStore>((set) => ({
       page: PAGE.PLACEDETAIL,
       placeId: placeId,
     })),
+  setPageGroupList:() =>
+    set(() => ({
+      page: PAGE.USERGROUPLIST,
+    })),
   setPlaceList: (placeList: PlaceListResponse) =>
     set(() => ({
       placeList: placeList,
@@ -47,10 +49,6 @@ export const useMapStore = create<MapStore>((set) => ({
   setPlaceDetail: (placeDetail: PlaceDetailResponse) =>
     set(() => ({
       placeDetail: placeDetail,
-    })),
-  setGroupModal: (groupModal: boolean) =>
-    set(() => ({
-      groupModal: !groupModal,
     })),
   setGroupList: (groupList: GroupListResponse[]) =>
     set(() => ({

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -7,7 +7,7 @@ import {
   PlaceListResponse,
 } from "@/types/map";
 
-type MapStore = {
+interface MapStore {
   page: PageType;
   placeList: PlaceListResponse | null;
   placeId: number | null;

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -12,14 +12,14 @@ type MapStore = {
   placeList: PlaceListResponse | null;
   placeId: number | null;
   placeDetail: PlaceDetailResponse | null;
-  groupList: GroupListResponse | null;
+  groupList: GroupListResponse[] | null;
   groupModal: boolean;
   setPagePlaceList: () => void;
   setPagePlaceDetail: (placeId: number) => void;
   setPlaceList: (placeList: PlaceListResponse) => void;
   setPlaceDetail: (placeDetail: PlaceDetailResponse) => void;
   setGroupModal: (groupModal: boolean) => void;
-  setGroupList: (groupList: GroupListResponse) => void;
+  setGroupList: (groupList: GroupListResponse[]) => void;
 };
 
 export const useMapStore = create<MapStore>((set) => ({
@@ -29,7 +29,7 @@ export const useMapStore = create<MapStore>((set) => ({
   placeId: null,
   placeDetail: null,
   groupModal: false,
-  groupList: null,
+  groupList: [],
 
   setPagePlaceList: () =>
     set(() => ({
@@ -52,7 +52,7 @@ export const useMapStore = create<MapStore>((set) => ({
     set(() => ({
       groupModal: !groupModal,
     })),
-  setGroupList: (groupList: GroupListResponse) =>
+  setGroupList: (groupList: GroupListResponse[]) =>
     set(() => ({
       groupList: groupList,
     })),

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -15,6 +15,7 @@ type MapStore = {
   setPagePlaceList: () => void;
   setPagePlaceDetail: (placeId: number) => void;
   setPlaceList: (placeList: PlaceListResponse) => void;
+  setPlaceDetail :(placeDetail: PlaceDetailResponse) => void;
 };
 
 export const useMapStore = create<MapStore>((set) => ({
@@ -37,5 +38,9 @@ export const useMapStore = create<MapStore>((set) => ({
   setPlaceList: (placeList: PlaceListResponse) =>
     set(() => ({
       placeList: placeList,
+    })),
+  setPlaceDetail: (placeDetail : PlaceDetailResponse) =>
+    set(() => ({
+      placeDetail: placeDetail,
     }))
 }));

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -37,6 +37,7 @@ export interface PlaceInfos {
 export const PAGE = {
   PLACELIST: "PLACELIST",
   PLACEDETAIL: "PLACEDETAIL",
+  USERGROUPLIST: "USERGROUPLIST",
 } as const;
 
 export type PageType = (typeof PAGE)[keyof typeof PAGE];

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -41,6 +41,7 @@ export const PAGE = {
 
 export type PageType = (typeof PAGE)[keyof typeof PAGE];
 
+export type GroupListResponseList = GroupListResponse[];
 
 export interface GroupListResponse {
   groupId: number;

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -40,3 +40,12 @@ export const PAGE = {
 } as const;
 
 export type PageType = (typeof PAGE)[keyof typeof PAGE];
+
+
+export interface GroupListResponse {
+  groupId: number;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  deleted: boolean;
+}

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -50,4 +50,5 @@ export interface GroupListResponse {
   createdAt: string;
   updatedAt: string;
   deleted: boolean;
+  groupFavoriteCount: number;
 }


### PR DESCRIPTION
## 📌 작업 개요
- 유저 그룹 리스트 조회 UI 및 API 연결과 Zustand를 적용했습니다.


## ✨ 주요 변경 사항
- 기존의 상태변수를 useState로 관리하는 방식에서 Zustand로 전역관리하도록 수정했습니다.
- 그룹 리스트 UI 구현
- 컴포넌트 간 전환 가능
- 해당 그룹을 클릭하면 해당 유저의 그룹 리스트가 조회됩니다.

## 스크린샷 (선택)
> https://github.com/user-attachments/assets/762283ec-34e9-416a-8e6f-7e35091c993f

## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [x] 반복 코드 함수로 분리

## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->
- 지도 페이지에서 인근 장소리스트를 조회하고, 장소를 클릭했을 때 유저들의 메모를 확인해볼 수 있습니다.
- 유저 클릭 시 해당 유저의 그룹 리스트를 조회할 수 있습니다.

## 💬 기타 참고 사항
- ⭐  현충일이니까 다들 쉬시고 월요일에 pr피드백 주셔도 좋습니다!!  ⭐ 
- 제가 코드에 확신이 없어서 한 커밋에 코드가 큼직큼직하게 들어가는 경우가 많습니다.. 커밋 잘 쪼개볼게요
- UI를 만들려다보니 데이터가 필요했고, 데이터를 불러오려고하니 useState로는 벅차서 Zustand까지 적용해버렸는데 브랜치 생성 의도와 맞지 않아서 다음부터는 유의해서 작업하도록 하겠습니다. PR 작업량이 너무 커져버렸네요..


> ![image](https://github.com/user-attachments/assets/c08a8db4-d071-4b0f-8342-b692fdd6c291)
- 이슈 #85 에서 API연동으로 수정할 예정입니다. 아직 백엔드 pr반영이 되지않아 작업못했습니다.
> ![image](https://github.com/user-attachments/assets/473008cd-cc66-4c34-a365-2ea1603f738e)
- 이슈 #77 #74  에서 상단 "서울시 > 강남구" 부분 수정해서 추후 반영하고, 즐겨찾기 많은 순으로 조회하도록 하겠습니다. 
- 사이드바 메뉴 연결도 #86 이슈 적어놨으니 추후 pr 올리겠습니다.