### PR TITLE
UI/map-favorite 즐겨찾기 추가 모달 UI 및 장소의 즐겨찾기 상태 API연결

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -7,18 +7,23 @@ import PlaceUserMemos from "@/components/map/PlaceUserMemos";
 import { PAGE } from "@/types/map";
 import { UserGroupList } from "@/components/map/UserGroupList";
 import { useMapStore } from "@/stores/mapStore";
+import { FavoriteAddModal } from "@/components/map/FavoriteAddModal";
 
 const MapPage = () => {
   const { page } = useMapStore((state) => state);
 
   return (
-    <div>
+    <div className="w-full h-full">
       <KakaoMap />
       <SideMenu />
 
       {page === PAGE.PLACELIST && <PlaceModal />}
       {page === PAGE.PLACEDETAIL && <PlaceUserMemos />}
       {page === PAGE.USERGROUPLIST && <UserGroupList />}
+
+      <FavoriteAddModal />
+
+
     </div>
   );
 };

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -10,7 +10,8 @@ import { useMapStore } from "@/stores/mapStore";
 import { FavoriteAddModal } from "@/components/map/FavoriteAddModal";
 
 const MapPage = () => {
-  const { page } = useMapStore((state) => state);
+  const { page, favoriteAddModal } = useMapStore((state) => state);
+  const { setFavoriteAddModal } = useMapStore();
 
   return (
     <div className="w-full h-full">
@@ -21,8 +22,11 @@ const MapPage = () => {
       {page === PAGE.PLACEDETAIL && <PlaceUserMemos />}
       {page === PAGE.USERGROUPLIST && <UserGroupList />}
 
-      <FavoriteAddModal />
-
+      {favoriteAddModal && <FavoriteAddModal /> }
+      <button className="absolute left-10 bg-amber-500 w-40 h-15 z-50"
+        onClick={() => setFavoriteAddModal(favoriteAddModal)}>
+        테스트용 즐겨찾기 모달 추가 버튼
+      </button>
 
     </div>
   );

--- a/src/components/map/FavoriteAddModal.tsx
+++ b/src/components/map/FavoriteAddModal.tsx
@@ -1,14 +1,17 @@
 import { X } from "lucide-react";
 import { useState } from "react";
+import { useMapStore } from "@/stores/mapStore";
 
 export function FavoriteAddModal() {
+  const favoriteAddModal = useMapStore((status) => status.favoriteAddModal);
+  const { setFavoriteAddModal } = useMapStore();
+
   const [selectedGroup, setSelectedGroup] = useState<string>("");
   const [newGroupName, setNewGroupName] = useState<string>("");
 
   const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSelectedGroup(e.target.value);
   };
-
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
@@ -65,7 +68,10 @@ export function FavoriteAddModal() {
         </div>
 
         <div className="flex justify-end space-x-2">
-          <button className="px-4 py-2 text-sm rounded-md bg-gray100 text-gray900 hover:bg-gray200">
+          <button
+            onClick={() => setFavoriteAddModal(favoriteAddModal)}
+            className="px-4 py-2 text-sm rounded-md bg-gray100 text-gray900 hover:bg-gray200"
+          >
             Close
           </button>
           <button className="px-4 py-2 text-sm rounded-md bg-violet800 text-white hover:bg-violet600">

--- a/src/components/map/FavoriteAddModal.tsx
+++ b/src/components/map/FavoriteAddModal.tsx
@@ -1,6 +1,15 @@
 import { X } from "lucide-react";
+import { useState } from "react";
 
 export function FavoriteAddModal() {
+  const [selectedGroup, setSelectedGroup] = useState<string>("");
+  const [newGroupName, setNewGroupName] = useState<string>("");
+
+  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedGroup(e.target.value);
+  };
+
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
       <div className="bg-white rounded-2xl shadow-xl w-full max-w-md p-6 relative">
@@ -17,14 +26,31 @@ export function FavoriteAddModal() {
           </label>
           <select
             className="w-full border border-gray-300  rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-400"
-            defaultValue=""
+            value={selectedGroup}
+            onChange={handleSelectChange}
           >
             <option value="" disabled>
               그룹을 선택해주세요.
             </option>
+            <option value="__new__">그룹 추가</option>
             <option value="group1">그룹 1</option>
             <option value="group2">그룹 2</option>
           </select>
+
+          {selectedGroup === "__new__" && (
+            <div className="mt-3">
+              <label className="block text-sm font-medium text-gray600 mb-1">
+                새 그룹 이름
+              </label>
+              <input
+                type="text"
+                value={newGroupName}
+                onChange={(e) => setNewGroupName(e.target.value)}
+                className="w-full border border-gray-300 rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-400"
+                placeholder="새 그룹 이름을 입력하세요"
+              />
+            </div>
+          )}
         </div>
 
         <div className="mb-6">

--- a/src/components/map/FavoriteAddModal.tsx
+++ b/src/components/map/FavoriteAddModal.tsx
@@ -18,7 +18,7 @@ export function FavoriteAddModal() {
       <div className="bg-white rounded-2xl shadow-xl w-full max-w-md p-6 relative">
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-lg font-semibold">즐겨찾기 추가</h2>
-          <button>
+          <button onClick={() => setFavoriteAddModal(favoriteAddModal)}>
             <X className="w-5 h-5 text-gray600" />
           </button>
         </div>

--- a/src/components/map/FavoriteAddModal.tsx
+++ b/src/components/map/FavoriteAddModal.tsx
@@ -7,7 +7,7 @@ export function FavoriteAddModal() {
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-lg font-semibold">즐겨찾기 추가</h2>
           <button>
-            <X className="w-5 h-5 text-gray-500" />
+            <X className="w-5 h-5 text-gray600" />
           </button>
         </div>
 
@@ -39,10 +39,10 @@ export function FavoriteAddModal() {
         </div>
 
         <div className="flex justify-end space-x-2">
-          <button className="px-4 py-2 text-sm rounded-md bg-gray-100 text-gray-800 hover:bg-gray-200">
+          <button className="px-4 py-2 text-sm rounded-md bg-gray100 text-gray900 hover:bg-gray200">
             Close
           </button>
-          <button className="px-4 py-2 text-sm rounded-md bg-purple-600 text-white hover:bg-purple-700">
+          <button className="px-4 py-2 text-sm rounded-md bg-violet800 text-white hover:bg-violet600">
             Apply
           </button>
         </div>

--- a/src/components/map/FavoriteAddModal.tsx
+++ b/src/components/map/FavoriteAddModal.tsx
@@ -12,11 +12,11 @@ export function FavoriteAddModal() {
         </div>
 
         <div className="mb-4">
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-gray600 mb-1">
             그룹 선택
           </label>
           <select
-            className="w-full border border-gray-300 rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-400"
+            className="w-full border border-gray-300  rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-400"
             defaultValue=""
           >
             <option value="" disabled>
@@ -28,8 +28,8 @@ export function FavoriteAddModal() {
         </div>
 
         <div className="mb-6">
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            메모 <span className="text-gray-400 text-xs">(Optional)</span>
+          <label className="block text-sm font-medium text-gray600 mb-1">
+            메모 <span className="text-gray600 text-xs">(Optional)</span>
           </label>
           <input
             type="text"

--- a/src/components/map/FavoriteAddModal.tsx
+++ b/src/components/map/FavoriteAddModal.tsx
@@ -1,0 +1,52 @@
+import { X } from "lucide-react";
+
+export function FavoriteAddModal() {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-md p-6 relative">
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-lg font-semibold">즐겨찾기 추가</h2>
+          <button>
+            <X className="w-5 h-5 text-gray-500" />
+          </button>
+        </div>
+
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            그룹 선택
+          </label>
+          <select
+            className="w-full border border-gray-300 rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-400"
+            defaultValue=""
+          >
+            <option value="" disabled>
+              그룹을 선택해주세요.
+            </option>
+            <option value="group1">그룹 1</option>
+            <option value="group2">그룹 2</option>
+          </select>
+        </div>
+
+        <div className="mb-6">
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            메모 <span className="text-gray-400 text-xs">(Optional)</span>
+          </label>
+          <input
+            type="text"
+            placeholder="메모를 작성해주세요."
+            className="w-full border border-gray-300 rounded-lg p-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-purple-400"
+          />
+        </div>
+
+        <div className="flex justify-end space-x-2">
+          <button className="px-4 py-2 text-sm rounded-md bg-gray-100 text-gray-800 hover:bg-gray-200">
+            Close
+          </button>
+          <button className="px-4 py-2 text-sm rounded-md bg-purple-600 text-white hover:bg-purple-700">
+            Apply
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -49,7 +49,7 @@ export default function KakaoMap() {
 
   return (
     <>
-      <div ref={mapRef} className={`w-screen h-screen`} />
+      <div ref={mapRef} className={`absolute w-screen h-screen left-0`} />
     </>
   );
 }

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -28,7 +28,7 @@ export default function PlaceModal() {
   }, []);
 
   return (
-    <div className="flex flex-col absolute -bottom-4 left-4 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
+    <div className="flex flex-col absolute -bottom-4 left-0 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
       {/* 헤더 */}
       <div className="px-4 pt-4">
         <span className="text-2xl font-extrabold block text-gray900">

--- a/src/components/map/PlaceUserMemos.tsx
+++ b/src/components/map/PlaceUserMemos.tsx
@@ -23,7 +23,7 @@ export default function PlaceUserMemos() {
   }, [placeId]);
 
   return (
-    <div className="flex flex-col absolute -bottom-4 left-4 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
+    <div className="flex flex-col absolute -bottom-4 left-0 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
       {placeDetail && (
         <>
           <PlaceUserMemosHeader placeDetail={placeDetail} />

--- a/src/components/map/PlaceUserMemosHeader.tsx
+++ b/src/components/map/PlaceUserMemosHeader.tsx
@@ -21,7 +21,6 @@ export default function PlaceUserMemosHeader({
       (async () => {
         try {
           const data = await fetchFavoriteStatus(placeId);
-          console.log("data(boolean) : ", data);
           setFavorite(data);
         } catch (error) {
           console.error("장소의 즐겨찾기 상태를 불러오는 데 실패했습니다", error);

--- a/src/components/map/PlaceUserMemosHeader.tsx
+++ b/src/components/map/PlaceUserMemosHeader.tsx
@@ -14,10 +14,6 @@ export default function PlaceUserMemosHeader({
 
   const [favorite, setFavorite] = useState(false);
 
-  function handleClickFavorite() {
-    setFavorite((prev) => !prev);
-  }
-
   return (
     <div className="relative w-full px-4 py-4">
       <div className="flex flex-col items-center justify-center">
@@ -26,11 +22,11 @@ export default function PlaceUserMemosHeader({
         </button>
 
         <div className="flex items-center space-x-2">
-          <button onClick={handleClickFavorite} className="flex self-start">
+          <div className="flex self-start">
             <LucideStar
               className={favorite ? " " : "text-yellow-400 fill-yellow-400"}
             />
-          </button>
+          </div>
 
           <div className="flex flex-col justify-center items-center text-center max-w-[200px]">
             <span className="font-bold text-gray900 text-lg leading-snug break-words">

--- a/src/components/map/PlaceUserMemosHeader.tsx
+++ b/src/components/map/PlaceUserMemosHeader.tsx
@@ -2,7 +2,7 @@ import { ArrowLeftIcon, LucideStar, MoreVerticalIcon } from "lucide-react";
 import React, { useEffect, useState } from "react";
 import { PlaceDetailResponse } from "@/types/map";
 import { useMapStore } from "@/stores/mapStore";
-import { fetchFavoriteStatus, fetchPlaceDetail } from "@/lib/api/map";
+import { fetchFavoriteStatus } from "@/lib/api/map";
 
 interface PlaceUserMemosHeaderProps {
   placeDetail: PlaceDetailResponse;

--- a/src/components/map/PlaceUserMemosHeader.tsx
+++ b/src/components/map/PlaceUserMemosHeader.tsx
@@ -1,7 +1,8 @@
 import { ArrowLeftIcon, LucideStar, MoreVerticalIcon } from "lucide-react";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { PlaceDetailResponse } from "@/types/map";
 import { useMapStore } from "@/stores/mapStore";
+import { fetchFavoriteStatus, fetchPlaceDetail } from "@/lib/api/map";
 
 interface PlaceUserMemosHeaderProps {
   placeDetail: PlaceDetailResponse;
@@ -11,8 +12,24 @@ export default function PlaceUserMemosHeader({
   placeDetail,
 }: PlaceUserMemosHeaderProps) {
   const { setPagePlaceList } = useMapStore();
+  const placeId = useMapStore((status) => status.placeId);
 
   const [favorite, setFavorite] = useState(false);
+
+  useEffect(() => {
+    if (placeId !== null) {
+      (async () => {
+        try {
+          const data = await fetchFavoriteStatus(placeId);
+          console.log("data(boolean) : ", data);
+          setFavorite(data);
+        } catch (error) {
+          console.error("장소의 즐겨찾기 상태를 불러오는 데 실패했습니다", error);
+        }
+      })();
+    }
+  }, [placeId]);
+
 
   return (
     <div className="relative w-full px-4 py-4">
@@ -24,7 +41,7 @@ export default function PlaceUserMemosHeader({
         <div className="flex items-center space-x-2">
           <div className="flex self-start">
             <LucideStar
-              className={favorite ? " " : "text-yellow-400 fill-yellow-400"}
+              className={favorite ? "text-yellow-400 fill-yellow-400" : " "}
             />
           </div>
 

--- a/src/components/map/SideMenu.tsx
+++ b/src/components/map/SideMenu.tsx
@@ -15,7 +15,7 @@ export default function SideMenu() {
 
   return (
     <div
-      className={`flex flex-nowrap w-24 h-auto justify-around p-4 absolute top-0 left-4 z-10  transition-colors duration-300 ${
+      className={`flex absolute flex-nowrap w-24 h-auto justify-around p-4 absolute top-0 left-0 z-10  transition-colors duration-300 ${
         openModal ? "bg-white shadow-md" : "bg-transparent"
       }`}
     >

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -29,7 +29,7 @@ export function UserGroupList() {
   return (
     <>
       {page === PAGE.USERGROUPLIST && (
-        <div className={`w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-4 bottom-[-1rem] z-10 flex flex-col`}>
+        <div className={`w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-0 bottom-[-1rem] z-10 flex flex-col`}>
           <div className="flex items-center justify-between px-4 py-2 border-b">
             {/* 뒤로 가기*/}
             <button

--- a/src/lib/api/map.ts
+++ b/src/lib/api/map.ts
@@ -24,3 +24,12 @@ export const fetchGroupList = async (userId: number): Promise<GroupListResponse[
     method: "GET",
   })
 }
+
+export const fetchFavoriteStatus = async(placeId : number) : Promise<boolean> => {
+  return await client<boolean>(`/favorite/check`, {
+    method: "GET",
+    params: {
+      placeId: placeId,
+    }
+  })
+}

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -30,6 +30,10 @@ interface MapStore {
   // 유저 그룹 리스트
   groupList: GroupListResponse[] | null;
   setGroupList: (groupList: GroupListResponse[]) => void;
+
+  // 즐겨찾기 추가 모달
+  favoriteAddModal: boolean;
+  setFavoriteAddModal: (favoriteAddModal:boolean) => void;
 };
 
 export const useMapStore = create<MapStore>((set) => ({
@@ -40,6 +44,7 @@ export const useMapStore = create<MapStore>((set) => ({
   placeDetail: null,
   groupList: [],
   otherUserId: null,
+  favoriteAddModal: false,
 
 
   setPagePlaceList: () =>
@@ -67,5 +72,9 @@ export const useMapStore = create<MapStore>((set) => ({
   setGroupList: (groupList: GroupListResponse[]) =>
     set(() => ({
       groupList: groupList,
+    })),
+  setFavoriteAddModal: (favoriteAddModal: boolean) =>
+    set(() => ({
+      favoriteAddModal: !favoriteAddModal,
     })),
 }));

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -8,17 +8,27 @@ import {
 } from "@/types/map";
 
 interface MapStore {
-  page: PageType;
-  placeList: PlaceListResponse | null;
+
+  // 상태 변수
   placeId: number | null;
-  placeDetail: PlaceDetailResponse | null;
-  groupList: GroupListResponse[] | null;
   otherUserId: number | null;
+
+  // 모달 페이지
+  page: PageType;
   setPagePlaceList: () => void;
   setPagePlaceDetail: (placeId: number) => void;
   setPageGroupList:(otherUserId: number) => void;
+
+  // 장소 리스트
+  placeList: PlaceListResponse | null;
   setPlaceList: (placeList: PlaceListResponse) => void;
+
+  // 장소 상세
+  placeDetail: PlaceDetailResponse | null;
   setPlaceDetail: (placeDetail: PlaceDetailResponse) => void;
+
+  // 유저 그룹 리스트
+  groupList: GroupListResponse[] | null;
   setGroupList: (groupList: GroupListResponse[]) => void;
 };
 


### PR DESCRIPTION
## 📌 작업 개요
- 즐겨찾기 추가 모달 UI 생성 및 장소의 즐겨찾기 상태 API연결


## ✨ 주요 변경 사항
- 테스트 버튼을 누르면 즐겨찾기 추가 모달이 펼쳐집니다.
- close 누르면 모달이 닫힙니다.
- 그룹 선택에서 "그룹 추가" 모달을 클릭하면 새 그룹이름을 입력할 수 있습니다.
- 그룹과 메모를 선택할 수 있습니다.
- 즐겨찾기 상태를 API 연결을 통해 불러오도록 수정했습니다.


## 🖼️ 스크린샷 (선택)

https://github.com/user-attachments/assets/16d68956-f313-4e54-b2fc-f3951da67cb3

- 즐겨찾기 모달 테스트 


https://github.com/user-attachments/assets/86cc0aa0-1eda-4bf4-9cb1-4e02b66f4c70

- 즐겨찾기 상태 Star에 반영 및 클릭 불가능한 요소로 변경


## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [x] 반복 코드 함수로 분리


## 📂 테스트 방법
- 임의의 데이터 (API 연결x) 로 지도 페이지에서 테스트했습니다.

## 💬 기타 참고 사항
close #85 
