### PR TITLE
회원 탈퇴 UI 구현 및 API 연결

### DIFF
--- a/src/app/withdrawal-complete/page.tsx
+++ b/src/app/withdrawal-complete/page.tsx
@@ -1,0 +1,9 @@
+import WithdrawalCompleteForm from "@/components/Setting/WithdrawalCompleteForm";
+
+export default function page() {
+  return (
+    <main className="flex justify-center items-center min-h-screen bg-white">
+      <WithdrawalCompleteForm />
+    </main>
+  );
+}

--- a/src/components/Setting/SettingComponent.tsx
+++ b/src/components/Setting/SettingComponent.tsx
@@ -27,7 +27,7 @@ const SettingComponent = ({ user }: SettingComponentProps) => {
       await withdrawUser(reason);
       await logout();
       useAuthStore.getState().clearUser();
-      router.push("/");
+      router.push("/withdrawal-complete");
     } catch (e) {
       console.error(e);
       alert("탈퇴에 실패했습니다.");

--- a/src/components/Setting/SettingComponent.tsx
+++ b/src/components/Setting/SettingComponent.tsx
@@ -4,18 +4,46 @@ import { UserInfo } from "@/stores/useAuthStore";
 import ProfileBaseInfoSection from "./ProfileBaseInfoSection";
 import ProfileInfoSection from "./ProfileInfoSection";
 import ProfileChangePassword from "./ProfileChangePassword";
+import WithdrawConfirmModal from "./WithdrawConfirmModal";
+import { useState } from "react";
 
 interface SettingComponentProps {
   user: UserInfo;
 }
 
 const SettingComponent = ({ user }: SettingComponentProps) => {
+  const [open, setOpen] = useState(false);
+
+  const handleWithdraw = () => {
+    setOpen(true);
+  };
+
+  const handleConfirm = (reason: string) => {
+    // 탈퇴 API 호출
+
+    console.log("탈퇴 사유:", reason);
+    setOpen(false);
+  };
+
   return (
     <div className="flex flex-col py-20 gap-4">
       <h1 className="text-2xl font-bold pb-4">계정 정보</h1>
       <ProfileBaseInfoSection user={user} />
       <ProfileInfoSection user={user} />
       <ProfileChangePassword />
+      <button
+        className="mt-6 text-sm text-gray600 underline item-center"
+        onClick={handleWithdraw}
+      >
+        회원 탈퇴하기
+      </button>
+
+      {/* 탈퇴 확인 모달 */}
+      <WithdrawConfirmModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        onConfirm={handleConfirm}
+      />
     </div>
   );
 };

--- a/src/components/Setting/SettingComponent.tsx
+++ b/src/components/Setting/SettingComponent.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { UserInfo } from "@/stores/useAuthStore";
+import { useAuthStore, UserInfo } from "@/stores/useAuthStore";
 import ProfileBaseInfoSection from "./ProfileBaseInfoSection";
 import ProfileInfoSection from "./ProfileInfoSection";
 import ProfileChangePassword from "./ProfileChangePassword";
 import WithdrawConfirmModal from "./WithdrawConfirmModal";
 import { useState } from "react";
+import { withdrawUser } from "@/lib/api/profile";
+import { logout } from "@/lib/api/auth";
+import { useRouter } from "next/navigation";
 
 interface SettingComponentProps {
   user: UserInfo;
@@ -13,16 +16,24 @@ interface SettingComponentProps {
 
 const SettingComponent = ({ user }: SettingComponentProps) => {
   const [open, setOpen] = useState(false);
+  const router = useRouter();
 
-  const handleWithdraw = () => {
+  const handleWithdrawModal = () => {
     setOpen(true);
   };
 
-  const handleConfirm = (reason: string) => {
-    // 탈퇴 API 호출
-
-    console.log("탈퇴 사유:", reason);
-    setOpen(false);
+  const handleConfirm = async (reason: string) => {
+    try {
+      await withdrawUser(reason);
+      await logout();
+      useAuthStore.getState().clearUser();
+      router.push("/");
+    } catch (e) {
+      console.error(e);
+      alert("탈퇴에 실패했습니다.");
+    } finally {
+      setOpen(false);
+    }
   };
 
   return (
@@ -33,7 +44,7 @@ const SettingComponent = ({ user }: SettingComponentProps) => {
       <ProfileChangePassword />
       <button
         className="mt-6 text-sm text-gray600 underline item-center"
-        onClick={handleWithdraw}
+        onClick={handleWithdrawModal}
       >
         회원 탈퇴하기
       </button>

--- a/src/components/Setting/WithdrawConfirmModal.tsx
+++ b/src/components/Setting/WithdrawConfirmModal.tsx
@@ -26,7 +26,7 @@ export default function WithdrawConfirmModal({
           placeholder="(선택) 탈퇴 사유를 입력해주세요"
           className="w-full px-3 py-3"
         />
-        <div className="flex justify-center gap-2">
+        <div className="flex justify-end gap-2">
           <button
             onClick={onClose}
             className="px-4 py-2 bg-gray200 hover:bg-gray100 rounded transition-colors"
@@ -35,7 +35,7 @@ export default function WithdrawConfirmModal({
           </button>
           <button
             onClick={() => onConfirm(reason)}
-            className="px-4 py-2 bg-red-400 hover:bg-red200 text-white rounded transition-colors"
+            className="px-4 py-2 bg-red500 hover:bg-red200 text-white rounded transition-colors"
           >
             탈퇴
           </button>

--- a/src/components/Setting/WithdrawConfirmModal.tsx
+++ b/src/components/Setting/WithdrawConfirmModal.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { useState } from "react";
+import BaseModal from "../common/Modal/BaseModal";
+import TextInput from "../common/Input/TextInput";
+
+export default function WithdrawConfirmModal({
+  isOpen,
+  onClose,
+  onConfirm,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (reason: string) => void;
+}) {
+  const [reason, setReason] = useState("");
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose}>
+      <div className="space-y-4">
+        <p className="text-lg font-semibold text-center">
+          정말 탈퇴하시겠어요?
+        </p>
+        <TextInput
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="(선택) 탈퇴 사유를 입력해주세요"
+          className="w-full px-3 py-3"
+        />
+        <div className="flex justify-center gap-2">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-gray200 hover:bg-gray100 rounded transition-colors"
+          >
+            취소
+          </button>
+          <button
+            onClick={() => onConfirm(reason)}
+            className="px-4 py-2 bg-red-400 hover:bg-red200 text-white rounded transition-colors"
+          >
+            탈퇴
+          </button>
+        </div>
+      </div>
+    </BaseModal>
+  );
+}

--- a/src/components/Setting/WithdrawalCompleteForm.tsx
+++ b/src/components/Setting/WithdrawalCompleteForm.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { LogoIcon } from "../common/Icons";
+import BaseButton from "../common/Button/BaseButton";
+
+const WithdrawalCompleteForm = () => {
+  const router = useRouter();
+
+  return (
+    <div className="w-full max-w-[430px] border border-violet300">
+      <div className="flex justify-center items-center pt-8 pb-4 gap-4">
+        <div className="flex justify-center items-center gap-4 text-2xl font-semibold text-violet800">
+          <LogoIcon />
+          <h1>ZARO</h1>
+        </div>
+      </div>
+      <div className="flex flex-col items-center text-center px-6 sm:px-12 py-10 gap-6">
+        <h2 className="text-xl font-bold text-gray900">
+          탈퇴가 완료되었습니다.
+        </h2>
+        <p className="text-md text-gray600 mb-10">
+          그동안 ZARO를 이용해주셔서 진심으로 감사합니다.
+        </p>
+        <BaseButton
+          type="button"
+          size="xl"
+          color="violet800"
+          className="w-full"
+          onClick={() => router.replace("/")}
+        >
+          홈으로 가기
+        </BaseButton>
+      </div>
+    </div>
+  );
+};
+
+export default WithdrawalCompleteForm;

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -16,6 +16,7 @@ export const Footer = () => {
     "/policy/privacy",
     "/editor",
     "/map",
+    "/withdrawal-complete",
   ];
 
   if (hideFooterRoutes.includes(pathname)) return null;

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -32,6 +32,7 @@ const Header = ({ onMenuClick }: HeaderProps) => {
     "/policy/terms",
     "/policy/privacy",
     "/map",
+    "/withdrawal-complete",
   ];
 
   // 검색창 숨김 경로 시작

--- a/src/lib/api/profile.ts
+++ b/src/lib/api/profile.ts
@@ -50,3 +50,13 @@ export const updateNickname = async (
     body: JSON.stringify({ newNickname: nickname }),
   });
 };
+
+export const withdrawUser = async (
+	reason: string,
+): Promise<void> => {
+	return await client("/users/me", {
+		method: "DELETE",
+		needAuth: true,
+		body: JSON.stringify({ reason }),
+	});
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,7 @@ const config = {
         skyblue300: "#D1D6E8",
 
         red200: "#FFA49D",
+        red500: "#F5535E",
         green200: "#C9EDE9",
 
         kakao: "#FEE500",


### PR DESCRIPTION
## 📌 작업 개요
회원 탈퇴 UI 구현 및 API 연결


## ✨ 주요 변경 사항
- 회원 탈퇴 버튼 + 탈퇴 모달 UI 구현
- 회원 탈퇴 API 연결
- 회원 탈퇴시 탈퇴 완료 페이지 
- 탈퇴 시 로그아웃 처리
- tailwind.config.js에 red500: "#F5535E" 추가 (별로다 싶으면 말씀주세요. 바로 롤백)


## 🖼️ 스크린샷 (선택)
탈퇴 버튼
![image](https://github.com/user-attachments/assets/e7d3f955-3985-494e-9b0b-4e78128b4d53)
탈퇴 모달
![image](https://github.com/user-attachments/assets/bd883c08-630d-4dd8-b738-b4d689b2107f)
탈퇴 완료 페이지
![image](https://github.com/user-attachments/assets/fb4c1d5b-b2e5-4131-ac75-517d9da19dab)


탈퇴 후...
![image](https://github.com/user-attachments/assets/633525a6-b995-4f0d-88b1-a6b4144dd785)


## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리


## 📂 테스트 방법


## 💬 기타 참고 사항
- reason은 선택사항입니다. null, ''(빈값) 가능
- 로그아웃 기능이 필요해서 로그아웃 브랜치에서 브랜치 따서 작업하고 main에 rebase했는데.. 컨플릭이 없습니다. 이상합니다. logout 없다고 에러는 나있는데 동작은 합니다. 매우 이상합니다. 잘 동작합니다..
