### PR TITLE
Feat/user-like-list 유저의 그룹에 대한 즐겨찾기 조회 UI, API 연결

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -8,6 +8,7 @@ import { PAGE } from "@/types/map";
 import { UserGroupList } from "@/components/map/UserGroupList";
 import { useMapStore } from "@/stores/mapStore";
 import { FavoriteAddModal } from "@/components/map/FavoriteAddModal";
+import { GroupsFavoriteList } from "@/components/map/GroupsFavoriteList";
 
 const MapPage = () => {
   const { page, favoriteAddModal } = useMapStore((state) => state);
@@ -21,6 +22,7 @@ const MapPage = () => {
       {page === PAGE.PLACELIST && <PlaceModal />}
       {page === PAGE.PLACEDETAIL && <PlaceUserMemos />}
       {page === PAGE.USERGROUPLIST && <UserGroupList />}
+      {page === PAGE.FAVORITELIST && <GroupsFavoriteList />}
 
       {favoriteAddModal && <FavoriteAddModal /> }
       <button className="absolute left-10 bg-amber-500 w-40 h-15 z-50"

--- a/src/components/map/FavoriteCard.tsx
+++ b/src/components/map/FavoriteCard.tsx
@@ -16,7 +16,7 @@ export function FavoriteCard({ favorite }: FavoriteCardProps) {
       >
         <div className="flex items-center gap-3">
           <div className="flex flex-col">
-            <span className="font-medium text-sm text-gray-900">
+            <span className="font-medium text-sm text-gray900">
               {favorite.placeName}
             </span>
             <span className="text-xs text-gray600">{favorite.address}</span>

--- a/src/components/map/FavoriteCard.tsx
+++ b/src/components/map/FavoriteCard.tsx
@@ -1,0 +1,44 @@
+import { FavoriteListResponse } from "@/types/map";
+import { MoreVertical, Star } from "lucide-react";
+import { useMapStore } from "@/stores/mapStore";
+
+interface FavoriteCardProps {
+  favorite: FavoriteListResponse;
+}
+
+export function FavoriteCard({ favorite }: FavoriteCardProps) {
+  const otherUserId = useMapStore((state) => state.otherUserId);
+  const { setPageGroupList } = useMapStore();
+
+  return(
+    <>
+      <li
+        className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
+        onClick={() => setPageGroupList(otherUserId!)}
+        key={favorite.id}
+      >
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 rounded-full bg-violet-100 flex items-center justify-center">
+            <Star size={16} className="text-violet-500" />
+          </div>
+          <div>
+            <div className="font-medium text-sm text-gray-900">
+              {favorite.placeName}
+            </div>
+            <div className="text-xs text-gray-600">
+              {/* 여기 응답 객체 백엔드단 코드 추가 되면 수정해야함!!!!!!!!!!!1*/}
+              {/*장소 {group.groupFavoriteCount}*/}
+            </div>
+          </div>
+        </div>
+        <button className="hover:bg-gray-200 rounded-full p-1">
+          <MoreVertical size={20} className="text-gray-400" />
+        </button>
+      </li>
+
+    </>
+  )
+
+
+
+}

--- a/src/components/map/FavoriteCard.tsx
+++ b/src/components/map/FavoriteCard.tsx
@@ -1,44 +1,34 @@
 import { FavoriteListResponse } from "@/types/map";
-import { MoreVertical, Star } from "lucide-react";
-import { useMapStore } from "@/stores/mapStore";
+import { MoreVertical } from "lucide-react";
 
 interface FavoriteCardProps {
   favorite: FavoriteListResponse;
 }
 
 export function FavoriteCard({ favorite }: FavoriteCardProps) {
-  const otherUserId = useMapStore((state) => state.otherUserId);
-  const { setPageGroupList } = useMapStore();
 
-  return(
+  return (
     <>
       <li
         className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
-        onClick={() => setPageGroupList(otherUserId!)}
+        // onClick={() => setPageGroupList(otherUserId!)}
         key={favorite.id}
       >
         <div className="flex items-center gap-3">
-          <div className="w-8 h-8 rounded-full bg-violet-100 flex items-center justify-center">
-            <Star size={16} className="text-violet-500" />
-          </div>
-          <div>
-            <div className="font-medium text-sm text-gray-900">
+          <div className="flex flex-col">
+            <span className="font-medium text-sm text-gray-900">
               {favorite.placeName}
-            </div>
-            <div className="text-xs text-gray-600">
-              {/* 여기 응답 객체 백엔드단 코드 추가 되면 수정해야함!!!!!!!!!!!1*/}
-              {/*장소 {group.groupFavoriteCount}*/}
-            </div>
+            </span>
+            <span className="text-xs text-gray600">{favorite.address}</span>
+            <span className="text-xs text-gray600 ">{favorite.memo}</span>
+
+            <div className="text-xs text-gray-600"></div>
           </div>
         </div>
         <button className="hover:bg-gray-200 rounded-full p-1">
           <MoreVertical size={20} className="text-gray-400" />
         </button>
       </li>
-
     </>
-  )
-
-
-
+  );
 }

--- a/src/components/map/FavoriteList.tsx
+++ b/src/components/map/FavoriteList.tsx
@@ -16,7 +16,6 @@ export function FavoriteList() {
           const data: FavoriteListResponse[] =
             await fetchFavoritesByGroup(groupId);
           setFavoriteList(data);
-          console.log("그룹 즐겨찾기 조회 성공");
         }
       } catch (error) {
         console.error(
@@ -36,7 +35,7 @@ export function FavoriteList() {
             <FavoriteCard favorite={favorite} key={idx} />
           ))
         ) : (
-          <FallbackMessage message="등록된 그룹이 없습니다." />
+          <FallbackMessage message="등록된 즐겨찾기가 없습니다." />
         )}
       </ul>
     </>

--- a/src/components/map/FavoriteList.tsx
+++ b/src/components/map/FavoriteList.tsx
@@ -4,10 +4,13 @@ import { FavoriteListResponse } from "@/types/map";
 import { fetchFavoritesByGroup } from "@/lib/api/map";
 import { useMapStore } from "@/stores/mapStore";
 import { FavoriteCard } from "@/components/map/FavoriteCard";
+import { useToastMessageContext } from "@/providers/ToastMessageProvider";
 
 export function FavoriteList() {
   const { groupId, favoriteList } = useMapStore((state) => state);
   const { setFavoriteList } = useMapStore();
+  const { showToastMessage } = useToastMessageContext();
+
 
   useEffect(() => {
     (async () => {
@@ -18,6 +21,7 @@ export function FavoriteList() {
           setFavoriteList(data);
         }
       } catch (error) {
+        showToastMessage({ type: "error", message: "그룹의 즐겨찾기 리스트를 불러오는 데 실패했습니다." });
         console.error(
           "그룹의 즐겨찾기 리스트를 불러오는 데 실패했습니다.",
           error,
@@ -28,7 +32,6 @@ export function FavoriteList() {
   }, [groupId]);
 
   return (
-    <>
       <ul className="flex-1 overflow-y-auto divide-y">
         {favoriteList && favoriteList.length > 0 ? (
           favoriteList.map((favorite, idx) => (
@@ -38,6 +41,5 @@ export function FavoriteList() {
           <FallbackMessage message="등록된 즐겨찾기가 없습니다." />
         )}
       </ul>
-    </>
   );
 }

--- a/src/components/map/FavoriteList.tsx
+++ b/src/components/map/FavoriteList.tsx
@@ -23,6 +23,7 @@ export function FavoriteList() {
           "그룹의 즐겨찾기 리스트를 불러오는 데 실패했습니다.",
           error,
         );
+        setFavoriteList([]);
       }
     })();
   }, [groupId]);
@@ -35,7 +36,7 @@ export function FavoriteList() {
             <FavoriteCard favorite={favorite} key={idx} />
           ))
         ) : (
-          <FallbackMessage className="등록된 그룹이 없습니다." />
+          <FallbackMessage message="등록된 그룹이 없습니다." />
         )}
       </ul>
     </>

--- a/src/components/map/FavoriteList.tsx
+++ b/src/components/map/FavoriteList.tsx
@@ -1,0 +1,43 @@
+import FallbackMessage from "@/components/common/Fallback/FallbackMessage";
+import { useEffect } from "react";
+import { FavoriteListResponse } from "@/types/map";
+import { fetchFavoritesByGroup } from "@/lib/api/map";
+import { useMapStore } from "@/stores/mapStore";
+import { FavoriteCard } from "@/components/map/FavoriteCard";
+
+export function FavoriteList() {
+  const { groupId, favoriteList } = useMapStore((state) => state);
+  const { setFavoriteList } = useMapStore();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        if (groupId != null) {
+          const data: FavoriteListResponse[] =
+            await fetchFavoritesByGroup(groupId);
+          setFavoriteList(data);
+          console.log("그룹 즐겨찾기 조회 성공");
+        }
+      } catch (error) {
+        console.error(
+          "그룹의 즐겨찾기 리스트를 불러오는 데 실패했습니다.",
+          error,
+        );
+      }
+    })();
+  }, [groupId]);
+
+  return (
+    <>
+      <ul className="flex-1 overflow-y-auto divide-y">
+        {favoriteList && favoriteList.length > 0 ? (
+          favoriteList.map((favorite, idx) => (
+            <FavoriteCard favorite={favorite} key={idx} />
+          ))
+        ) : (
+          <FallbackMessage className="등록된 그룹이 없습니다." />
+        )}
+      </ul>
+    </>
+  );
+}

--- a/src/components/map/GroupCard.tsx
+++ b/src/components/map/GroupCard.tsx
@@ -1,0 +1,35 @@
+import { MoreVertical, Star } from "lucide-react";
+import { GroupListResponse } from "@/types/map";
+
+
+interface GroupCardProps {
+  group : GroupListResponse,
+}
+
+export function GroupCard ( {group} : GroupCardProps) {
+  return (
+    <>
+      <li
+        className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
+      >
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 rounded-full bg-violet-100 flex items-center justify-center">
+            <Star size={16} className="text-violet-500" />
+          </div>
+          <div>
+            <div className="font-medium text-sm text-gray-900">
+              {group.name}
+            </div>
+            <div className="text-xs text-gray-600">
+              {/* 여기 응답 객체 백엔드단 코드 추가 되면 수정해야함!!!!!!!!!!!1*/}
+              장소 {group.groupFavoriteCount}
+            </div>
+          </div>
+        </div>
+        <button className="hover:bg-gray-200 rounded-full p-1">
+          <MoreVertical size={20} className="text-gray-400" />
+        </button>
+      </li>
+    </>
+  );
+}

--- a/src/components/map/GroupCard.tsx
+++ b/src/components/map/GroupCard.tsx
@@ -7,13 +7,18 @@ interface GroupCardProps {
 }
 
 export function GroupCard({ group }: GroupCardProps) {
-  const { setPageFavoriteList } = useMapStore();
+  const { setPageFavoriteList, setGroupInfo } = useMapStore();
+
+  const handleClick = () => {
+    setGroupInfo(group);
+    setPageFavoriteList(group.groupId);
+  };
 
   return (
     <>
       <li
         className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
-        onClick={() => setPageFavoriteList(group.groupId)}
+        onClick={handleClick}
         key={group.groupId}
       >
         <div className="flex items-center gap-3">
@@ -25,7 +30,6 @@ export function GroupCard({ group }: GroupCardProps) {
               {group.name}
             </div>
             <div className="text-xs text-gray-600">
-              {/* 여기 응답 객체 백엔드단 코드 추가 되면 수정해야함!!!!!!!!!!!1*/}
               장소 {group.groupFavoriteCount}
             </div>
           </div>

--- a/src/components/map/GroupCard.tsx
+++ b/src/components/map/GroupCard.tsx
@@ -15,7 +15,6 @@ export function GroupCard({ group }: GroupCardProps) {
   };
 
   return (
-    <>
       <li
         className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
         onClick={handleClick}
@@ -38,6 +37,5 @@ export function GroupCard({ group }: GroupCardProps) {
           <MoreVertical size={20} className="text-gray-400" />
         </button>
       </li>
-    </>
   );
 }

--- a/src/components/map/GroupCard.tsx
+++ b/src/components/map/GroupCard.tsx
@@ -1,16 +1,20 @@
 import { MoreVertical, Star } from "lucide-react";
 import { GroupListResponse } from "@/types/map";
-
+import { useMapStore } from "@/stores/mapStore";
 
 interface GroupCardProps {
-  group : GroupListResponse,
+  group: GroupListResponse;
 }
 
-export function GroupCard ( {group} : GroupCardProps) {
+export function GroupCard({ group }: GroupCardProps) {
+  const { setPageFavoriteList } = useMapStore();
+
   return (
     <>
       <li
         className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
+        onClick={() => setPageFavoriteList(group.groupId)}
+        key={group.groupId}
       >
         <div className="flex items-center gap-3">
           <div className="w-8 h-8 rounded-full bg-violet-100 flex items-center justify-center">

--- a/src/components/map/GroupCardList.tsx
+++ b/src/components/map/GroupCardList.tsx
@@ -4,10 +4,13 @@ import { GroupListResponse } from "@/types/map";
 import { fetchGroupList } from "@/lib/api/map";
 import { useMapStore } from "@/stores/mapStore";
 import { GroupCard } from "@/components/map/GroupCard";
+import { useToastMessageContext } from "@/providers/ToastMessageProvider";
 
 export function GroupCardList() {
   const { groupList, otherUserId } = useMapStore((state) => state);
   const { setGroupList } = useMapStore();
+  const { showToastMessage } = useToastMessageContext();
+
 
   useEffect(() => {
     (async () => {
@@ -17,13 +20,13 @@ export function GroupCardList() {
           setGroupList(data);
         }
       } catch (error) {
-        console.error("유저의 그룹 리스트를 불러오는 데 실패했습니다.", error);
+        showToastMessage({ type: "error", message: "유저의 그룹 리스트를 불러오는 데 실패했습니다" });
+        console.error(".", error);
       }
     })();
   }, [otherUserId]);
 
   return (
-    <>
       <ul className="flex-1 overflow-y-auto divide-y">
         {groupList && groupList.length > 0 ? (
           groupList.map((group, idx) => <GroupCard group={group} key={idx} />)
@@ -31,6 +34,5 @@ export function GroupCardList() {
           <FallbackMessage className="등록된 그룹이 없습니다." />
         )}
       </ul>
-    </>
   );
 }

--- a/src/components/map/GroupCardList.tsx
+++ b/src/components/map/GroupCardList.tsx
@@ -1,6 +1,6 @@
 import FallbackMessage from "@/components/common/Fallback/FallbackMessage";
 import { useEffect } from "react";
-import { GroupListResponseList } from "@/types/map";
+import { GroupListResponse } from "@/types/map";
 import { fetchGroupList } from "@/lib/api/map";
 import { useMapStore } from "@/stores/mapStore";
 import { GroupCard } from "@/components/map/GroupCard";
@@ -13,7 +13,7 @@ export function GroupCardList() {
     (async () => {
       try {
         if (otherUserId != null) {
-          const data: GroupListResponseList = await fetchGroupList(otherUserId);
+          const data: GroupListResponse[] = await fetchGroupList(otherUserId);
           setGroupList(data);
         }
       } catch (error) {

--- a/src/components/map/GroupCardList.tsx
+++ b/src/components/map/GroupCardList.tsx
@@ -1,0 +1,35 @@
+import FallbackMessage from "@/components/common/Fallback/FallbackMessage";
+import { useEffect } from "react";
+import { GroupListResponseList } from "@/types/map";
+import { fetchGroupList } from "@/lib/api/map";
+import { useMapStore } from "@/stores/mapStore";
+import { GroupCard } from "@/components/map/GroupCard";
+
+export function GroupCardList() {
+  const { groupList, otherUserId } = useMapStore((state) => state);
+  const { setGroupList } = useMapStore();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        if (otherUserId != null) {
+          const data: GroupListResponseList = await fetchGroupList(otherUserId);
+          setGroupList(data);
+        }
+      } catch (error) {
+        console.error("유저의 그룹 리스트를 불러오는 데 실패했습니다.", error);
+      }
+    })();
+  }, [otherUserId]);
+  return (
+    <>
+      <ul className="flex-1 overflow-y-auto divide-y">
+        {groupList && groupList.length > 0 ? (
+          groupList.map((group, idx) => <GroupCard group={group} key={idx} />)
+        ) : (
+          <FallbackMessage className="등록된 그룹이 없습니다." />
+        )}
+      </ul>
+    </>
+  );
+}

--- a/src/components/map/GroupCardList.tsx
+++ b/src/components/map/GroupCardList.tsx
@@ -21,6 +21,7 @@ export function GroupCardList() {
       }
     })();
   }, [otherUserId]);
+
   return (
     <>
       <ul className="flex-1 overflow-y-auto divide-y">

--- a/src/components/map/GroupsFavoriteList.tsx
+++ b/src/components/map/GroupsFavoriteList.tsx
@@ -4,13 +4,12 @@ import { useMapStore } from "@/stores/mapStore";
 import { PAGE } from "@/types/map";
 import { useProfile } from "@/hooks/useProfile";
 import { FavoriteList } from "@/components/map/FavoriteList";
+import { getDdayFromDate } from "@/utils/date";
 
 export function GroupsFavoriteList() {
   const {  page, otherUserId } = useMapStore((state) => state);
   const { setPageGroupList } = useMapStore();
   const { data: profile } = useProfile(otherUserId);
-
-
 
   return (
     <>
@@ -39,7 +38,7 @@ export function GroupsFavoriteList() {
                 {profile?.nickname}
               </span>
               <span className="text-sm text-gray-500">
-                {profile?.liveAloneDate ?? "등록된 자취 시작일이 없습니다."}
+                {getDdayFromDate(profile?.liveAloneDate)}
               </span>
             </div>
           </div>

--- a/src/components/map/GroupsFavoriteList.tsx
+++ b/src/components/map/GroupsFavoriteList.tsx
@@ -7,7 +7,9 @@ import { FavoriteList } from "@/components/map/FavoriteList";
 import { getDdayFromDate } from "@/utils/date";
 
 export function GroupsFavoriteList() {
-  const {  page, otherUserId } = useMapStore((state) => state);
+  const { page, otherUserId, groupInfo } = useMapStore(
+    (state) => state,
+  );
   const { setPageGroupList } = useMapStore();
   const { data: profile } = useProfile(otherUserId);
 
@@ -42,6 +44,14 @@ export function GroupsFavoriteList() {
               </span>
             </div>
           </div>
+
+          <div className="flex flex-col justify-center items-center p-4">
+            <span className="font-bold">{groupInfo?.name}</span>
+            <span className="text-xs text-gray600">
+              장소 {groupInfo?.groupFavoriteCount}
+            </span>
+          </div>
+
           <FavoriteList />
         </div>
       )}

--- a/src/components/map/GroupsFavoriteList.tsx
+++ b/src/components/map/GroupsFavoriteList.tsx
@@ -1,0 +1,72 @@
+import { ArrowLeft, MoreVertical, Star } from "lucide-react";
+import { DefaultProfileIcon } from "@/components/common/Icons";
+import { useMapStore } from "@/stores/mapStore";
+import FallbackMessage from "@/components/common/Fallback/FallbackMessage";
+
+export function GroupsFavoriteList() {
+  const { groupList, placeId, page, otherUserId } = useMapStore((state) => state);
+
+
+
+  return (
+    <>
+      {page === PAGE.FAVORITELIST && (
+        <div className={`w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-0 bottom-[-1rem] z-10 flex flex-col`}>
+          <div className="flex items-center justify-between px-4 py-2 border-b">
+            {/* 뒤로 가기*/}
+            <button
+              onClick={() => setPagePlaceDetail(placeId!)}
+              className="p-1 rounded-full hover:bg-gray-100"
+            >
+              <ArrowLeft size={20} className="text-gray-700" />
+            </button>
+            <div className="text-sm font-medium text-gray-600">그룹 목록</div>
+            <div className="w-6" />
+          </div>
+
+          <div className="flex flex-col items-center py-4 border-b">
+            <DefaultProfileIcon className="w-10 h-10 rounded-full object-cover" />
+            <span className="font-semibold text-lg mt-2">{profile?.nickname}</span>
+            <span className="text-sm text-gray-500">{profile?.liveAloneDate}</span>
+          </div>
+
+          <ul className="flex-1 overflow-y-auto divide-y">
+            {groupList && groupList.length > 0 ? (
+              groupList.map((group, idx) => (
+                <li
+                  key={idx}
+                  className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-full bg-violet-100 flex items-center justify-center">
+                      <Star size={16} className="text-violet-500" />
+                    </div>
+                    <div>
+                      <div className="font-medium text-sm text-gray-900">
+                        {group.name}
+                      </div>
+                      <div className="text-xs text-gray-600">
+                        {/* 여기 응답 객체 백엔드단 코드 추가 되면 수정해야함!!!!!!!!!!!1*/}
+                        장소 {group.groupFavoriteCount ?? 0}
+                      </div>
+                    </div>
+                  </div>
+                  <button className="hover:bg-gray-200 rounded-full p-1">
+                    <MoreVertical size={20} className="text-gray-400" />
+                  </button>
+                </li>
+              ))
+            ) : (
+              <FallbackMessage
+                className="등록된 그룹이 없습니다."
+              />
+              // <div className="text-sm text-gray-600 text-center py-10">
+              //   등록된 그룹이 없습니다.
+              // </div>
+            )}
+          </ul>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/map/GroupsFavoriteList.tsx
+++ b/src/components/map/GroupsFavoriteList.tsx
@@ -7,54 +7,47 @@ import { FavoriteList } from "@/components/map/FavoriteList";
 import { getDdayFromDate } from "@/utils/date";
 
 export function GroupsFavoriteList() {
-  const { page, otherUserId, groupInfo } = useMapStore(
-    (state) => state,
-  );
+  const { page, otherUserId, groupInfo } = useMapStore((state) => state);
   const { setPageGroupList } = useMapStore();
   const { data: profile } = useProfile(otherUserId);
 
-  return (
-    <>
-      {page === PAGE.FAVORITELIST && (
-        <div
-          className={`w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-0 bottom-[-1rem] z-10 flex flex-col`}
-        >
-          <div className="flex items-center justify-between px-4 py-2 border-b">
-            {/* 뒤로 가기*/}
-            <button
-              onClick={() => setPageGroupList(otherUserId!)}
-              className="p-1 rounded-full hover:bg-gray-100"
-            >
-              <ArrowLeft size={20} className="text-gray-700" />
-            </button>
-            <div className="text-sm font-medium text-gray-600">
-              즐겨찾기 목록
-            </div>
-            <div className="w-6" />
-          </div>
+  if (page === PAGE.FAVORITELIST)
+    return (
+      <div
+        className={`w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-0 bottom-[-1rem] z-10 flex flex-col`}
+      >
+        <div className="flex items-center justify-between px-4 py-2 border-b">
+          {/* 뒤로 가기*/}
+          <button
+            onClick={() => setPageGroupList(otherUserId!)}
+            className="p-1 rounded-full hover:bg-gray-100"
+          >
+            <ArrowLeft size={20} className="text-gray-700" />
+          </button>
+          <div className="text-sm font-medium text-gray-600">즐겨찾기 목록</div>
+          <div className="w-6" />
+        </div>
 
-          <div className="flex gap-4 justify-center items-center py-4 border-b">
-            <DefaultProfileIcon className="w-10 h-10 rounded-full object-cover" />
-            <div className="flex flex-col">
-              <span className="font-semibold text-lg mt-2">
-                {profile?.nickname}
-              </span>
-              <span className="text-sm text-gray-500">
-                {getDdayFromDate(profile?.liveAloneDate)}
-              </span>
-            </div>
-          </div>
-
-          <div className="flex flex-col justify-center items-center p-4">
-            <span className="font-bold">{groupInfo?.name}</span>
-            <span className="text-xs text-gray600">
-              장소 {groupInfo?.groupFavoriteCount}
+        <div className="flex gap-4 justify-center items-center py-4 border-b">
+          <DefaultProfileIcon className="w-10 h-10 rounded-full object-cover" />
+          <div className="flex flex-col">
+            <span className="font-semibold text-lg mt-2">
+              {profile?.nickname}
+            </span>
+            <span className="text-sm text-gray-500">
+              {getDdayFromDate(profile?.liveAloneDate)}
             </span>
           </div>
-
-          <FavoriteList />
         </div>
-      )}
-    </>
-  );
+
+        <div className="flex flex-col justify-center items-center p-4">
+          <span className="font-bold">{groupInfo?.name}</span>
+          <span className="text-xs text-gray600">
+            장소 {groupInfo?.groupFavoriteCount}
+          </span>
+        </div>
+
+        <FavoriteList />
+      </div>
+    );
 }

--- a/src/components/map/GroupsFavoriteList.tsx
+++ b/src/components/map/GroupsFavoriteList.tsx
@@ -1,15 +1,13 @@
 import { ArrowLeft } from "lucide-react";
 import { DefaultProfileIcon } from "@/components/common/Icons";
 import { useMapStore } from "@/stores/mapStore";
-import { FavoriteListResponse, PAGE } from "@/types/map";
-import { useEffect } from "react";
-import { fetchFavoritesByGroup } from "@/lib/api/map";
+import { PAGE } from "@/types/map";
 import { useProfile } from "@/hooks/useProfile";
 import { FavoriteList } from "@/components/map/FavoriteList";
 
 export function GroupsFavoriteList() {
-  const { groupId, page, otherUserId } = useMapStore((state) => state);
-  const { setFavoriteList, setPageGroupList } = useMapStore();
+  const {  page, otherUserId } = useMapStore((state) => state);
+  const { setPageGroupList } = useMapStore();
   const { data: profile } = useProfile(otherUserId);
 
 

--- a/src/components/map/GroupsFavoriteList.tsx
+++ b/src/components/map/GroupsFavoriteList.tsx
@@ -1,70 +1,64 @@
-import { ArrowLeft, MoreVertical, Star } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { DefaultProfileIcon } from "@/components/common/Icons";
 import { useMapStore } from "@/stores/mapStore";
-import FallbackMessage from "@/components/common/Fallback/FallbackMessage";
+import { FavoriteListResponse, PAGE } from "@/types/map";
+import { useEffect } from "react";
+import { fetchFavoritesByGroup } from "@/lib/api/map";
+import { useProfile } from "@/hooks/useProfile";
 
 export function GroupsFavoriteList() {
-  const { groupList, placeId, page, otherUserId } = useMapStore((state) => state);
+  const { groupId, page, otherUserId } = useMapStore((state) => state);
+  const { setFavoriteList, setPageGroupList } = useMapStore();
+  const { data: profile } = useProfile(otherUserId);
 
-
+  useEffect(() => {
+    (async () => {
+      try {
+        if (groupId != null) {
+          const data: FavoriteListResponse[] =
+            await fetchFavoritesByGroup(groupId);
+          setFavoriteList(data);
+        }
+      } catch (error) {
+        console.error(
+          "그룹의 즐겨찾기 리스트를 불러오는 데 실패했습니다.",
+          error,
+        );
+      }
+    })();
+  }, [groupId]);
 
   return (
     <>
       {page === PAGE.FAVORITELIST && (
-        <div className={`w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-0 bottom-[-1rem] z-10 flex flex-col`}>
+        <div
+          className={`w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-0 bottom-[-1rem] z-10 flex flex-col`}
+        >
           <div className="flex items-center justify-between px-4 py-2 border-b">
             {/* 뒤로 가기*/}
             <button
-              onClick={() => setPagePlaceDetail(placeId!)}
+              onClick={() => setPageGroupList(otherUserId!)}
               className="p-1 rounded-full hover:bg-gray-100"
             >
               <ArrowLeft size={20} className="text-gray-700" />
             </button>
-            <div className="text-sm font-medium text-gray-600">그룹 목록</div>
+            <div className="text-sm font-medium text-gray-600">
+              즐겨찾기 목록
+            </div>
             <div className="w-6" />
           </div>
 
-          <div className="flex flex-col items-center py-4 border-b">
+          <div className="flex gap-4 justify-center items-center py-4 border-b">
             <DefaultProfileIcon className="w-10 h-10 rounded-full object-cover" />
-            <span className="font-semibold text-lg mt-2">{profile?.nickname}</span>
-            <span className="text-sm text-gray-500">{profile?.liveAloneDate}</span>
+            <div className="flex flex-col">
+              <span className="font-semibold text-lg mt-2">
+                {profile?.nickname}
+              </span>
+              <span className="text-sm text-gray-500">
+                {profile?.liveAloneDate ?? "등록된 자취 시작일이 없습니다."}
+              </span>
+            </div>
           </div>
-
-          <ul className="flex-1 overflow-y-auto divide-y">
-            {groupList && groupList.length > 0 ? (
-              groupList.map((group, idx) => (
-                <li
-                  key={idx}
-                  className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 rounded-full bg-violet-100 flex items-center justify-center">
-                      <Star size={16} className="text-violet-500" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-sm text-gray-900">
-                        {group.name}
-                      </div>
-                      <div className="text-xs text-gray-600">
-                        {/* 여기 응답 객체 백엔드단 코드 추가 되면 수정해야함!!!!!!!!!!!1*/}
-                        장소 {group.groupFavoriteCount ?? 0}
-                      </div>
-                    </div>
-                  </div>
-                  <button className="hover:bg-gray-200 rounded-full p-1">
-                    <MoreVertical size={20} className="text-gray-400" />
-                  </button>
-                </li>
-              ))
-            ) : (
-              <FallbackMessage
-                className="등록된 그룹이 없습니다."
-              />
-              // <div className="text-sm text-gray-600 text-center py-10">
-              //   등록된 그룹이 없습니다.
-              // </div>
-            )}
-          </ul>
         </div>
       )}
     </>

--- a/src/components/map/GroupsFavoriteList.tsx
+++ b/src/components/map/GroupsFavoriteList.tsx
@@ -5,28 +5,14 @@ import { FavoriteListResponse, PAGE } from "@/types/map";
 import { useEffect } from "react";
 import { fetchFavoritesByGroup } from "@/lib/api/map";
 import { useProfile } from "@/hooks/useProfile";
+import { FavoriteList } from "@/components/map/FavoriteList";
 
 export function GroupsFavoriteList() {
   const { groupId, page, otherUserId } = useMapStore((state) => state);
   const { setFavoriteList, setPageGroupList } = useMapStore();
   const { data: profile } = useProfile(otherUserId);
 
-  useEffect(() => {
-    (async () => {
-      try {
-        if (groupId != null) {
-          const data: FavoriteListResponse[] =
-            await fetchFavoritesByGroup(groupId);
-          setFavoriteList(data);
-        }
-      } catch (error) {
-        console.error(
-          "그룹의 즐겨찾기 리스트를 불러오는 데 실패했습니다.",
-          error,
-        );
-      }
-    })();
-  }, [groupId]);
+
 
   return (
     <>
@@ -59,6 +45,7 @@ export function GroupsFavoriteList() {
               </span>
             </div>
           </div>
+          <FavoriteList />
         </div>
       )}
     </>

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -36,7 +36,7 @@ export default function KakaoMap() {
     script.onload = () => {
       if (!window.kakao || !window.kakao.maps) return;
 
-      const kakao = window.kakao;
+      // const kakao = window.kakao;
 
       window.kakao.maps.load(() => {
         const container = mapRef.current;
@@ -47,7 +47,7 @@ export default function KakaoMap() {
           const lng = position.coords.longitude;
           const userLocation = new window.kakao.maps.LatLng(lat, lng);
 
-          const map = new window.kakao.maps.Map(container, {
+          new window.kakao.maps.Map(container, {
             center: userLocation,
             level: 3,
           });

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -3,25 +3,25 @@
 import { useEffect, useRef } from "react";
 
 // Kakao 객체를 전역 선언합니다.
-// declare global {
-//   interface Window {
-//     kakao: {
-//       maps: {
-//         LatLng: new (lat: number, lng: number) => void;
-//         Map: new (
-//           container: HTMLElement,
-//           options: { center: void; level: number },
-//         ) => void;
-//         load: (callback: () => void) => void;
-//       };
-//     };
-//   }
-// }
 declare global {
   interface Window {
-    kakao: any; // kakao.maps.* 전부 포괄
+    kakao: {
+      maps: {
+        LatLng: new (lat: number, lng: number) => void;
+        Map: new (
+          container: HTMLElement,
+          options: { center: void; level: number },
+        ) => void;
+        load: (callback: () => void) => void;
+      };
+    };
   }
 }
+// declare global {
+//   interface Window {
+//     kakao: any; // kakao.maps.* 전부 포괄
+//   }
+// }
 
 export default function KakaoMap() {
   const KAKAO_MAP_API_KEY = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID; // 카카오지도 api
@@ -52,111 +52,111 @@ export default function KakaoMap() {
             level: 3,
           });
 
-          // 마커를 클릭하면 장소명을 표출할 인포윈도우 입니다
-          const infowindow = new kakao.maps.InfoWindow({ zIndex: 1 });
-
-          // 장소 검색 객체를 생성합니다
-          const ps = new kakao.maps.services.Places();
-
-          // 키워드로 장소를 검색합니다
-          ps.keywordSearch("동현피트니스", placesSearchCB);
-
-          // 키워드 검색 완료 시 호출되는 콜백함수 입니다
-          function placesSearchCB(data, status, pagination) {
-            if (status === kakao.maps.services.Status.OK) {
-              // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
-              // LatLngBounds 객체에 좌표를 추가합니다
-              const bounds = new kakao.maps.LatLngBounds();
-
-              for (let i = 0; i < data.length; i++) {
-                displayMarker(data[i]);
-                bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
-              }
-
-              // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
-              map.setBounds(bounds);
-            }
-          }
-
-          // 지도에 마커를 표시하는 함수입니다
-          function displayMarker(place) {
-            // 마커를 생성하고 지도에 표시합니다
-            const marker = new kakao.maps.Marker({
-              map: map,
-              position: new kakao.maps.LatLng(place.y, place.x),
-            });
-
-            // 마커에 클릭이벤트를 등록합니다
-            kakao.maps.event.addListener(marker, "click", function () {
-              // 마커를 클릭하면 장소명이 인포윈도우에 표출됩니다
-              infowindow.setContent(
-                '<div style="padding:5px;font-size:12px;height:50px;">' +
-                place.place_name +
-                "placeId: " +
-                place.id +
-                "</div>",
-              );
-              infowindow.open(map, marker);
-            });
-          }
-
-
-        },
-          () => {
-            // 실패 시 기본 위치 (서울 시청)
-            const defaultCenter = new kakao.maps.LatLng(37.5665, 126.978);
-            const map = new kakao.maps.Map(container, {
-              center: defaultCenter,
-              level: 5,
-            });
-
-            // 마커를 클릭하면 장소명을 표출할 인포윈도우 입니다
-            const infowindow = new kakao.maps.InfoWindow({ zIndex: 1 });
-
-            // 장소 검색 객체를 생성합니다
-            const ps = new kakao.maps.services.Places();
-
-            // 키워드로 장소를 검색합니다
-            ps.keywordSearch("동현피트니스", placesSearchCB);
-
-            // 키워드 검색 완료 시 호출되는 콜백함수 입니다
-            function placesSearchCB(data, status, pagination) {
-              if (status === kakao.maps.services.Status.OK) {
-                // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
-                // LatLngBounds 객체에 좌표를 추가합니다
-                const bounds = new kakao.maps.LatLngBounds();
-
-                for (let i = 0; i < data.length; i++) {
-                  displayMarker(data[i]);
-                  bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
-                }
-
-                // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
-                map.setBounds(bounds);
-              }
-            }
-
-            // 지도에 마커를 표시하는 함수입니다
-            function displayMarker(place) {
-              // 마커를 생성하고 지도에 표시합니다
-              const marker = new kakao.maps.Marker({
-                map: map,
-                position: new kakao.maps.LatLng(place.y, place.x),
-              });
-
-              // 마커에 클릭이벤트를 등록합니다
-              kakao.maps.event.addListener(marker, "click", function () {
-                // 마커를 클릭하면 장소명이 인포윈도우에 표출됩니다
-                infowindow.setContent(
-                  '<div style="padding:5px;font-size:12px;height:50px;">' +
-                  place.place_name +
-                  "placeId: " +
-                  place.id +
-                  "</div>",
-                );
-                infowindow.open(map, marker);
-              });
-            }
+        //   // 마커를 클릭하면 장소명을 표출할 인포윈도우 입니다
+        //   const infowindow = new kakao.maps.InfoWindow({ zIndex: 1 });
+        //
+        //   // 장소 검색 객체를 생성합니다
+        //   const ps = new kakao.maps.services.Places();
+        //
+        //   // 키워드로 장소를 검색합니다
+        //   ps.keywordSearch("동현피트니스", placesSearchCB);
+        //
+        //   // 키워드 검색 완료 시 호출되는 콜백함수 입니다
+        //   function placesSearchCB(data, status, pagination) {
+        //     if (status === kakao.maps.services.Status.OK) {
+        //       // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
+        //       // LatLngBounds 객체에 좌표를 추가합니다
+        //       const bounds = new kakao.maps.LatLngBounds();
+        //
+        //       for (let i = 0; i < data.length; i++) {
+        //         displayMarker(data[i]);
+        //         bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
+        //       }
+        //
+        //       // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
+        //       map.setBounds(bounds);
+        //     }
+        //   }
+        //
+        //   // 지도에 마커를 표시하는 함수입니다
+        //   function displayMarker(place) {
+        //     // 마커를 생성하고 지도에 표시합니다
+        //     const marker = new kakao.maps.Marker({
+        //       map: map,
+        //       position: new kakao.maps.LatLng(place.y, place.x),
+        //     });
+        //
+        //     // 마커에 클릭이벤트를 등록합니다
+        //     kakao.maps.event.addListener(marker, "click", function () {
+        //       // 마커를 클릭하면 장소명이 인포윈도우에 표출됩니다
+        //       infowindow.setContent(
+        //         '<div style="padding:5px;font-size:12px;height:50px;">' +
+        //         place.place_name +
+        //         "placeId: " +
+        //         place.id +
+        //         "</div>",
+        //       );
+        //       infowindow.open(map, marker);
+        //     });
+        //   }
+        //
+        //
+        // },
+        //   () => {
+        //     // 실패 시 기본 위치 (서울 시청)
+        //     const defaultCenter = new kakao.maps.LatLng(37.5665, 126.978);
+        //     const map = new kakao.maps.Map(container, {
+        //       center: defaultCenter,
+        //       level: 5,
+        //     });
+        //
+        //     // 마커를 클릭하면 장소명을 표출할 인포윈도우 입니다
+        //     const infowindow = new kakao.maps.InfoWindow({ zIndex: 1 });
+        //
+        //     // 장소 검색 객체를 생성합니다
+        //     const ps = new kakao.maps.services.Places();
+        //
+        //     // 키워드로 장소를 검색합니다
+        //     ps.keywordSearch("동현피트니스", placesSearchCB);
+        //
+        //     // 키워드 검색 완료 시 호출되는 콜백함수 입니다
+        //     function placesSearchCB(data, status, pagination) {
+        //       if (status === kakao.maps.services.Status.OK) {
+        //         // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
+        //         // LatLngBounds 객체에 좌표를 추가합니다
+        //         const bounds = new kakao.maps.LatLngBounds();
+        //
+        //         for (let i = 0; i < data.length; i++) {
+        //           displayMarker(data[i]);
+        //           bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
+        //         }
+        //
+        //         // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
+        //         map.setBounds(bounds);
+        //       }
+        //     }
+        //
+        //     // 지도에 마커를 표시하는 함수입니다
+        //     function displayMarker(place) {
+        //       // 마커를 생성하고 지도에 표시합니다
+        //       const marker = new kakao.maps.Marker({
+        //         map: map,
+        //         position: new kakao.maps.LatLng(place.y, place.x),
+        //       });
+        //
+        //       // 마커에 클릭이벤트를 등록합니다
+        //       kakao.maps.event.addListener(marker, "click", function () {
+        //         // 마커를 클릭하면 장소명이 인포윈도우에 표출됩니다
+        //         infowindow.setContent(
+        //           '<div style="padding:5px;font-size:12px;height:50px;">' +
+        //           place.place_name +
+        //           "placeId: " +
+        //           place.id +
+        //           "</div>",
+        //         );
+        //         infowindow.open(map, marker);
+        //       });
+        //     }
 
 
           }

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -3,18 +3,23 @@
 import { useEffect, useRef } from "react";
 
 // Kakao 객체를 전역 선언합니다.
+// declare global {
+//   interface Window {
+//     kakao: {
+//       maps: {
+//         LatLng: new (lat: number, lng: number) => void;
+//         Map: new (
+//           container: HTMLElement,
+//           options: { center: void; level: number },
+//         ) => void;
+//         load: (callback: () => void) => void;
+//       };
+//     };
+//   }
+// }
 declare global {
   interface Window {
-    kakao: {
-      maps: {
-        LatLng: new (lat: number, lng: number) => void;
-        Map: new (
-          container: HTMLElement,
-          options: { center: void; level: number },
-        ) => void;
-        load: (callback: () => void) => void;
-      };
-    };
+    kakao: any; // kakao.maps.* 전부 포괄
   }
 }
 
@@ -31,17 +36,141 @@ export default function KakaoMap() {
     script.onload = () => {
       if (!window.kakao || !window.kakao.maps) return;
 
+      const kakao = window.kakao;
+
       window.kakao.maps.load(() => {
         const container = mapRef.current;
         if (!container) return;
 
-        // ✅ LatLng도 반드시 이 안에서 선언해야 안전
-        const defaultCenter = new window.kakao.maps.LatLng(37.5665, 126.978);
+        navigator.geolocation.getCurrentPosition((position) => {
+          const lat = position.coords.latitude;
+          const lng = position.coords.longitude;
+          const userLocation = new window.kakao.maps.LatLng(lat, lng);
 
-        new window.kakao.maps.Map(container, {
-          center: defaultCenter,
-          level: 3,
-        });
+          const map = new window.kakao.maps.Map(container, {
+            center: userLocation,
+            level: 3,
+          });
+
+          // 마커를 클릭하면 장소명을 표출할 인포윈도우 입니다
+          const infowindow = new kakao.maps.InfoWindow({ zIndex: 1 });
+
+          // 장소 검색 객체를 생성합니다
+          const ps = new kakao.maps.services.Places();
+
+          // 키워드로 장소를 검색합니다
+          ps.keywordSearch("동현피트니스", placesSearchCB);
+
+          // 키워드 검색 완료 시 호출되는 콜백함수 입니다
+          function placesSearchCB(data, status, pagination) {
+            if (status === kakao.maps.services.Status.OK) {
+              // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
+              // LatLngBounds 객체에 좌표를 추가합니다
+              const bounds = new kakao.maps.LatLngBounds();
+
+              for (let i = 0; i < data.length; i++) {
+                displayMarker(data[i]);
+                bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
+              }
+
+              // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
+              map.setBounds(bounds);
+            }
+          }
+
+          // 지도에 마커를 표시하는 함수입니다
+          function displayMarker(place) {
+            // 마커를 생성하고 지도에 표시합니다
+            const marker = new kakao.maps.Marker({
+              map: map,
+              position: new kakao.maps.LatLng(place.y, place.x),
+            });
+
+            // 마커에 클릭이벤트를 등록합니다
+            kakao.maps.event.addListener(marker, "click", function () {
+              // 마커를 클릭하면 장소명이 인포윈도우에 표출됩니다
+              infowindow.setContent(
+                '<div style="padding:5px;font-size:12px;height:50px;">' +
+                place.place_name +
+                "placeId: " +
+                place.id +
+                "</div>",
+              );
+              infowindow.open(map, marker);
+            });
+          }
+
+
+        },
+          () => {
+            // 실패 시 기본 위치 (서울 시청)
+            const defaultCenter = new kakao.maps.LatLng(37.5665, 126.978);
+            const map = new kakao.maps.Map(container, {
+              center: defaultCenter,
+              level: 5,
+            });
+
+            // 마커를 클릭하면 장소명을 표출할 인포윈도우 입니다
+            const infowindow = new kakao.maps.InfoWindow({ zIndex: 1 });
+
+            // 장소 검색 객체를 생성합니다
+            const ps = new kakao.maps.services.Places();
+
+            // 키워드로 장소를 검색합니다
+            ps.keywordSearch("동현피트니스", placesSearchCB);
+
+            // 키워드 검색 완료 시 호출되는 콜백함수 입니다
+            function placesSearchCB(data, status, pagination) {
+              if (status === kakao.maps.services.Status.OK) {
+                // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
+                // LatLngBounds 객체에 좌표를 추가합니다
+                const bounds = new kakao.maps.LatLngBounds();
+
+                for (let i = 0; i < data.length; i++) {
+                  displayMarker(data[i]);
+                  bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
+                }
+
+                // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
+                map.setBounds(bounds);
+              }
+            }
+
+            // 지도에 마커를 표시하는 함수입니다
+            function displayMarker(place) {
+              // 마커를 생성하고 지도에 표시합니다
+              const marker = new kakao.maps.Marker({
+                map: map,
+                position: new kakao.maps.LatLng(place.y, place.x),
+              });
+
+              // 마커에 클릭이벤트를 등록합니다
+              kakao.maps.event.addListener(marker, "click", function () {
+                // 마커를 클릭하면 장소명이 인포윈도우에 표출됩니다
+                infowindow.setContent(
+                  '<div style="padding:5px;font-size:12px;height:50px;">' +
+                  place.place_name +
+                  "placeId: " +
+                  place.id +
+                  "</div>",
+                );
+                infowindow.open(map, marker);
+              });
+            }
+
+
+          }
+
+
+          );
+
+        // const defaultCenter = new window.kakao.maps.LatLng(37.5665, 126.978);
+
+
+
+
+
+
       });
     };
     document.head.appendChild(script);

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -3,10 +3,13 @@ import PlaceCard from "@/components/map/PlaceCard";
 import { PlaceListResponse } from "@/types/map";
 import { fetchPlaceList } from "@/lib/api/map";
 import { useMapStore } from "@/stores/mapStore";
+import { useToastMessageContext } from "@/providers/ToastMessageProvider";
 
 export default function PlaceModal() {
   const placeList = useMapStore((state) => state.placeList);
   const { setPlaceList } = useMapStore();
+  const { showToastMessage } = useToastMessageContext();
+
 
   useEffect(() => {
     const lat = 37.554722;
@@ -22,6 +25,7 @@ export default function PlaceModal() {
         );
         setPlaceList(data);
       } catch (error) {
+        showToastMessage({type: "error", message: "장소 목록을 불러오는 데 실패했습니다."})
         console.error("장소 목록을 불러오는 데 실패했습니다.", error);
       }
     })();

--- a/src/components/map/PlaceUserMemos.tsx
+++ b/src/components/map/PlaceUserMemos.tsx
@@ -4,10 +4,13 @@ import { BookmarkInfo } from "@/components/map/BookmarkInfo";
 import { UserMemoCards } from "@/components/map/UserMemoCards";
 import { fetchPlaceDetail } from "@/lib/api/map";
 import { useMapStore } from "@/stores/mapStore";
+import { useToastMessageContext } from "@/providers/ToastMessageProvider";
 
 export default function PlaceUserMemos() {
   const { placeId, placeDetail } = useMapStore((state) => state);
   const { setPlaceDetail } = useMapStore();
+  const { showToastMessage } = useToastMessageContext();
+
 
   useEffect(() => {
     if (placeId !== null) {
@@ -16,6 +19,7 @@ export default function PlaceUserMemos() {
           const data = await fetchPlaceDetail(placeId);
           setPlaceDetail(data);
         } catch (error) {
+          showToastMessage({type: "error", message: "장소 상세 정보를 불러오는 데 실패했습니다."})
           console.error("장소 상세 정보를 불러오는 데 실패했습니다.", error);
         }
       })();

--- a/src/components/map/PlaceUserMemosHeader.tsx
+++ b/src/components/map/PlaceUserMemosHeader.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { PlaceDetailResponse } from "@/types/map";
 import { useMapStore } from "@/stores/mapStore";
 import { fetchFavoriteStatus } from "@/lib/api/map";
+import { useToastMessageContext } from "@/providers/ToastMessageProvider";
 
 interface PlaceUserMemosHeaderProps {
   placeDetail: PlaceDetailResponse;
@@ -13,6 +14,8 @@ export default function PlaceUserMemosHeader({
 }: PlaceUserMemosHeaderProps) {
   const { setPagePlaceList } = useMapStore();
   const placeId = useMapStore((status) => status.placeId);
+  const { showToastMessage } = useToastMessageContext();
+
 
   const [favorite, setFavorite] = useState(false);
 
@@ -23,6 +26,7 @@ export default function PlaceUserMemosHeader({
           const data = await fetchFavoriteStatus(placeId);
           setFavorite(data);
         } catch (error) {
+          showToastMessage({ type : "error", message: "장소의 즐겨찾기 상태를 불러오는 데 실패했습니다."})
           console.error("장소의 즐겨찾기 상태를 불러오는 데 실패했습니다", error);
         }
       })();

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -4,6 +4,7 @@ import { PAGE } from "@/types/map";
 import { useMapStore } from "@/stores/mapStore";
 import { useProfile } from "@/hooks/useProfile";
 import { GroupCardList } from "@/components/map/GroupCardList";
+import { getDdayFromDate } from "@/utils/date";
 
 export function UserGroupList() {
   const { placeId, page, otherUserId } = useMapStore((state) => state);
@@ -36,7 +37,7 @@ export function UserGroupList() {
                 {profile?.nickname}
               </span>
               <span className="text-sm text-gray-500">
-                {profile?.liveAloneDate ?? "등록된 자취 시작일이 없습니다."}
+                {getDdayFromDate(profile?.liveAloneDate)}
               </span>
             </div>
           </div>

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -28,14 +28,17 @@ export function UserGroupList() {
             <div className="w-6" />
           </div>
 
-          <div className="flex flex-col items-center py-4 border-b">
+          <div className="flex justify-center gap-4 items-center py-4 border-b">
             <DefaultProfileIcon className="w-10 h-10 rounded-full object-cover" />
-            <span className="font-semibold text-lg mt-2">
-              {profile?.nickname}
-            </span>
-            <span className="text-sm text-gray-500">
-              {profile?.liveAloneDate}
-            </span>
+
+            <div className="flex flex-col">
+              <span className="font-semibold text-lg mt-2">
+                {profile?.nickname}
+              </span>
+              <span className="text-sm text-gray-500">
+                {profile?.liveAloneDate ?? "등록된 자취 시작일이 없습니다."}
+              </span>
+            </div>
           </div>
 
           <GroupCardList />

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -11,40 +11,37 @@ export function UserGroupList() {
   const { setPagePlaceDetail } = useMapStore();
   const { data: profile } = useProfile(otherUserId);
 
+  if (page === PAGE.USERGROUPLIST)
   return (
-    <>
-      {page === PAGE.USERGROUPLIST && (
-        <div
-          className={`w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-0 bottom-[-1rem] z-10 flex flex-col`}
+    <div
+      className={`w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-0 bottom-[-1rem] z-10 flex flex-col`}
+    >
+      <div className="flex items-center justify-between px-4 py-2 border-b">
+        {/* 뒤로 가기*/}
+        <button
+          onClick={() => setPagePlaceDetail(placeId!)}
+          className="p-1 rounded-full hover:bg-gray-100"
         >
-          <div className="flex items-center justify-between px-4 py-2 border-b">
-            {/* 뒤로 가기*/}
-            <button
-              onClick={() => setPagePlaceDetail(placeId!)}
-              className="p-1 rounded-full hover:bg-gray-100"
-            >
-              <ArrowLeft size={20} className="text-gray-700" />
-            </button>
-            <div className="text-sm font-medium text-gray-600">그룹 목록</div>
-            <div className="w-6" />
-          </div>
+          <ArrowLeft size={20} className="text-gray-700" />
+        </button>
+        <div className="text-sm font-medium text-gray-600">그룹 목록</div>
+        <div className="w-6" />
+      </div>
 
-          <div className="flex justify-center gap-4 items-center py-4 border-b">
-            <DefaultProfileIcon className="w-10 h-10 rounded-full object-cover" />
+      <div className="flex justify-center gap-4 items-center py-4 border-b">
+        <DefaultProfileIcon className="w-10 h-10 rounded-full object-cover" />
 
-            <div className="flex flex-col">
-              <span className="font-semibold text-lg mt-2">
-                {profile?.nickname}
-              </span>
-              <span className="text-sm text-gray-500">
-                {getDdayFromDate(profile?.liveAloneDate)}
-              </span>
-            </div>
-          </div>
-
-          <GroupCardList />
+        <div className="flex flex-col">
+          <span className="font-semibold text-lg mt-2">
+            {profile?.nickname}
+          </span>
+          <span className="text-sm text-gray-500">
+            {getDdayFromDate(profile?.liveAloneDate)}
+          </span>
         </div>
-      )}
-    </>
+      </div>
+
+      <GroupCardList />
+    </div>
   );
 }

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -1,35 +1,21 @@
-import { ArrowLeft, MoreVertical, Star } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { DefaultProfileIcon } from "@/components/common/Icons";
-import { useEffect } from "react";
-import { GroupListResponseList, PAGE } from "@/types/map";
-import { fetchGroupList } from "@/lib/api/map";
+import { PAGE } from "@/types/map";
 import { useMapStore } from "@/stores/mapStore";
 import { useProfile } from "@/hooks/useProfile";
-import FallbackMessage from "@/components/common/Fallback/FallbackMessage";
+import { GroupCardList } from "@/components/map/GroupCardList";
 
 export function UserGroupList() {
-  const { groupList, placeId, page, otherUserId } = useMapStore((state) => state);
-  const { setGroupList, setPagePlaceDetail } = useMapStore();
+  const { placeId, page, otherUserId } = useMapStore((state) => state);
+  const { setPagePlaceDetail } = useMapStore();
   const { data: profile } = useProfile(otherUserId);
-
-  useEffect(() => {
-    (async () => {
-      try {
-        if (otherUserId != null) {
-          const data: GroupListResponseList = await fetchGroupList(otherUserId);
-          setGroupList(data);
-        }
-
-      } catch (error) {
-        console.error("유저의 그룹 리스트를 불러오는 데 실패했습니다.", error);
-      }
-    })();
-  }, [otherUserId]);
 
   return (
     <>
       {page === PAGE.USERGROUPLIST && (
-        <div className={`w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-0 bottom-[-1rem] z-10 flex flex-col`}>
+        <div
+          className={`w-[24rem] h-[24rem] rounded-t-2xl shadow-lg overflow-hidden bg-white absolute left-0 bottom-[-1rem] z-10 flex flex-col`}
+        >
           <div className="flex items-center justify-between px-4 py-2 border-b">
             {/* 뒤로 가기*/}
             <button
@@ -44,45 +30,15 @@ export function UserGroupList() {
 
           <div className="flex flex-col items-center py-4 border-b">
             <DefaultProfileIcon className="w-10 h-10 rounded-full object-cover" />
-            <span className="font-semibold text-lg mt-2">{profile?.nickname}</span>
-            <span className="text-sm text-gray-500">{profile?.liveAloneDate}</span>
+            <span className="font-semibold text-lg mt-2">
+              {profile?.nickname}
+            </span>
+            <span className="text-sm text-gray-500">
+              {profile?.liveAloneDate}
+            </span>
           </div>
 
-          <ul className="flex-1 overflow-y-auto divide-y">
-            {groupList && groupList.length > 0 ? (
-              groupList.map((group, idx) => (
-                <li
-                  key={idx}
-                  className="flex items-center justify-between px-4 py-3 hover:bg-gray-50"
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 rounded-full bg-violet-100 flex items-center justify-center">
-                      <Star size={16} className="text-violet-500" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-sm text-gray-900">
-                        {group.name}
-                      </div>
-                      <div className="text-xs text-gray-600">
-                        {/* 여기 응답 객체 백엔드단 코드 추가 되면 수정해야함!!!!!!!!!!!1*/}
-                        장소 {group.groupFavoriteCount ?? 0}
-                      </div>
-                    </div>
-                  </div>
-                  <button className="hover:bg-gray-200 rounded-full p-1">
-                    <MoreVertical size={20} className="text-gray-400" />
-                  </button>
-                </li>
-              ))
-            ) : (
-              <FallbackMessage
-                className="등록된 그룹이 없습니다."
-              />
-              // <div className="text-sm text-gray-600 text-center py-10">
-              //   등록된 그룹이 없습니다.
-              // </div>
-            )}
-          </ul>
+          <GroupCardList />
         </div>
       )}
     </>

--- a/src/components/map/UserMemoCard.tsx
+++ b/src/components/map/UserMemoCard.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image";
 import { getProfileImageUrl } from "@/utils/image";
 import { useMapStore } from "@/stores/mapStore";
-import { useEffect } from "react";
 
 interface UserMemoProps {
   userId: number;
@@ -16,13 +15,7 @@ export default function UserMemoCard({
   nickName,
   memo,
 }: UserMemoProps) {
-  const page = useMapStore((state) => state.page);
   const { setPageGroupList } = useMapStore();
-
-
-  useEffect(() => {
-    console.log("page : ", page);
-  }, [page]);
 
   return (
     <li className="flex items-center hover:bg-gray100 transition p-1">

--- a/src/lib/api/map.ts
+++ b/src/lib/api/map.ts
@@ -1,5 +1,10 @@
 import { client } from "@/lib/fetch/client";
-import { PlaceListResponse, PlaceDetailResponse, GroupListResponse } from "@/types/map";
+import {
+  PlaceListResponse,
+  PlaceDetailResponse,
+  GroupListResponse,
+  FavoriteListResponse,
+} from "@/types/map";
 
 // lat, lng, distanceKm을 파라미터로 받아 사용
 export const fetchPlaceList = async (
@@ -31,5 +36,11 @@ export const fetchFavoriteStatus = async(placeId : number) : Promise<boolean> =>
     params: {
       placeId: placeId,
     }
+  })
+}
+
+export const fetchFavoritesByGroup = async (groupId: number): Promise<FavoriteListResponse[]> => {
+  return await client<FavoriteListResponse[]>(`/favorite/${groupId}/items`, {
+    method: "GET",
   })
 }

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import {
+  FavoriteListResponse,
   GroupListResponse,
   PAGE,
   PageType,
@@ -32,6 +33,10 @@ interface MapStore {
   groupList: GroupListResponse[] | null;
   setGroupList: (groupList: GroupListResponse[]) => void;
 
+  // 즐겨찾기 리스트
+  favoriteList: FavoriteListResponse[] | null;
+  setFavoriteList: (favoriteList: FavoriteListResponse[]) => void;
+
   // 즐겨찾기 추가 모달
   favoriteAddModal: boolean;
   setFavoriteAddModal: (favoriteAddModal: boolean) => void;
@@ -47,6 +52,7 @@ export const useMapStore = create<MapStore>((set) => ({
   groupList: [],
   otherUserId: null,
   favoriteAddModal: false,
+  favoriteList: null,
 
   setPagePlaceList: () =>
     set(() => ({
@@ -82,5 +88,9 @@ export const useMapStore = create<MapStore>((set) => ({
     set(() => ({
       groupId: grouId,
       page: PAGE.FAVORITELIST,
+    })),
+  setFavoriteList: (favoriteList: FavoriteListResponse[]) =>
+    set(() => ({
+      favoriteList: favoriteList
     })),
 }));

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -7,6 +7,7 @@ import {
   PlaceDetailResponse,
   PlaceListResponse,
 } from "@/types/map";
+import { Group } from "next/dist/shared/lib/router/utils/route-regex";
 
 interface MapStore {
   // 상태 변수
@@ -36,6 +37,8 @@ interface MapStore {
   // 즐겨찾기 리스트
   favoriteList: FavoriteListResponse[] | null;
   setFavoriteList: (favoriteList: FavoriteListResponse[]) => void;
+  groupInfo: GroupListResponse | null;
+  setGroupInfo: (groupInfo : GroupListResponse) => void;
 
   // 즐겨찾기 추가 모달
   favoriteAddModal: boolean;
@@ -53,6 +56,7 @@ export const useMapStore = create<MapStore>((set) => ({
   otherUserId: null,
   favoriteAddModal: false,
   favoriteList: null,
+  groupInfo: null,
 
   setPagePlaceList: () =>
     set(() => ({
@@ -93,4 +97,8 @@ export const useMapStore = create<MapStore>((set) => ({
     set(() => ({
       favoriteList: favoriteList
     })),
+  setGroupInfo: (groupInfo: GroupListResponse) =>
+    set(() => ({
+      groupInfo: groupInfo,
+    }))
 }));

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -8,16 +8,17 @@ import {
 } from "@/types/map";
 
 interface MapStore {
-
   // 상태 변수
   placeId: number | null;
   otherUserId: number | null;
+  groupId: number | null;
 
   // 모달 페이지
   page: PageType;
   setPagePlaceList: () => void;
   setPagePlaceDetail: (placeId: number) => void;
-  setPageGroupList:(otherUserId: number) => void;
+  setPageGroupList: (otherUserId: number) => void;
+  setPageFavoriteList: (groupId: number) => void;
 
   // 장소 리스트
   placeList: PlaceListResponse | null;
@@ -33,19 +34,19 @@ interface MapStore {
 
   // 즐겨찾기 추가 모달
   favoriteAddModal: boolean;
-  setFavoriteAddModal: (favoriteAddModal:boolean) => void;
-};
+  setFavoriteAddModal: (favoriteAddModal: boolean) => void;
+}
 
 export const useMapStore = create<MapStore>((set) => ({
   // 초기값
   page: PAGE.PLACELIST,
   placeList: null,
   placeId: null,
+  groupId: null,
   placeDetail: null,
   groupList: [],
   otherUserId: null,
   favoriteAddModal: false,
-
 
   setPagePlaceList: () =>
     set(() => ({
@@ -56,7 +57,7 @@ export const useMapStore = create<MapStore>((set) => ({
       page: PAGE.PLACEDETAIL,
       placeId: placeId,
     })),
-  setPageGroupList:(otherUserId: number) =>
+  setPageGroupList: (otherUserId: number) =>
     set(() => ({
       page: PAGE.USERGROUPLIST,
       otherUserId: otherUserId,
@@ -76,5 +77,10 @@ export const useMapStore = create<MapStore>((set) => ({
   setFavoriteAddModal: (favoriteAddModal: boolean) =>
     set(() => ({
       favoriteAddModal: !favoriteAddModal,
+    })),
+  setPageFavoriteList: (grouId: number) =>
+    set(() => ({
+      groupId: grouId,
+      page: PAGE.FAVORITELIST,
     })),
 }));

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -7,7 +7,6 @@ import {
   PlaceDetailResponse,
   PlaceListResponse,
 } from "@/types/map";
-import { Group } from "next/dist/shared/lib/router/utils/route-regex";
 
 interface MapStore {
   // 상태 변수

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -53,3 +53,20 @@ export interface GroupListResponse {
   deleted: boolean;
   groupFavoriteCount: number;
 }
+
+export type FavoriteListResponseList = FavoriteListResponse[];
+
+export interface FavoriteListResponse {
+  id: number,
+  userId: number,
+  groupId: number,
+  placeId: number,
+  placeName: string,
+  lat: number,
+  lng: number,
+  memo: string,
+  createdAt: string,
+  updatedAt: string,
+  address: string,
+  deleted: boolean
+}

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -43,8 +43,6 @@ export const PAGE = {
 
 export type PageType = (typeof PAGE)[keyof typeof PAGE];
 
-export type GroupListResponseList = GroupListResponse[];
-
 export interface GroupListResponse {
   groupId: number;
   name: string;
@@ -53,8 +51,6 @@ export interface GroupListResponse {
   deleted: boolean;
   groupFavoriteCount: number;
 }
-
-export type FavoriteListResponseList = FavoriteListResponse[];
 
 export interface FavoriteListResponse {
   id: number,

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -38,6 +38,7 @@ export const PAGE = {
   PLACELIST: "PLACELIST",
   PLACEDETAIL: "PLACEDETAIL",
   USERGROUPLIST: "USERGROUPLIST",
+  FAVORITELIST: "FAVORITELIST,"
 } as const;
 
 export type PageType = (typeof PAGE)[keyof typeof PAGE];

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -107,7 +107,7 @@ export const formatDate = (val: string): string => {
   return parts.join(".");
 };
 
-export function getDdayFromDate(dateString?: string | null | undefined): string {
+export function getDdayFromDate(dateString?: string | null): string {
   if (!dateString) return "D+?";
 
   const start = new Date(dateString);

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -106,3 +106,19 @@ export const formatDate = (val: string): string => {
 
   return parts.join(".");
 };
+
+export function getDdayFromDate(dateString?: string | null | undefined): string {
+  if (!dateString) return "D+?";
+
+  const start = new Date(dateString);
+  const today = new Date();
+
+  // 시간 요소 제거 (날짜만 비교)
+  start.setHours(0, 0, 0, 0);
+  today.setHours(0, 0, 0, 0);
+
+  const diff = today.getTime() - start.getTime();
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+  return `D+${days}`;
+}


### PR DESCRIPTION
## 📌 작업 개요
- 유저의 그룹에 대한 즐겨찾기 조회 UI, API 연결


## ✨ 주요 변경 사항
- zustand 적용
- 그룹의 즐겨찾기 리스트 조회 UI 
- 그룹의 즐겨찾기 리스트 조회 API 연결 완료
- 자취 시작일 정보 없을 시  "D + ? " 로 출력
- 자취 시작일 정보 있을 시 계산된 "D + ??" 로 출력
- 즐겨찾기 등록이 안되어있을 때 예외 메시지 "등록된 즐겨찾기가 없습니다" 출력
- D+day 계산 메서드 util에 추가


## 🖼️ 스크린샷 (선택)
https://github.com/user-attachments/assets/33157a9c-63a0-4baf-a4dd-39c53225268c

- 각 그룹에 대한 즐겨찾기리스트를 조회하고, 즐겨찾기가 추가되어있지 않을 때 예외 메시지를 출력합니다.

> ![image](https://github.com/user-attachments/assets/c52a70d7-836a-4ef0-9cde-eedc7bf51d78)
> ![image](https://github.com/user-attachments/assets/f2457955-4af3-4033-97dd-d319a2abd5fa)

- 그룹 목록 페이지와 즐겨찾기 페이지에서 DB에 저장된 날짜를 기반으로 D+ 를 계산해줍니다.

> ![image](https://github.com/user-attachments/assets/28cb9caf-b1c3-4e70-9612-73a0ee2fe111)
- 해당 그룹의 즐겨찾기가 정상적으로 조회됩니다.

> ![image](https://github.com/user-attachments/assets/4d83aaaf-2ab8-4454-82d9-eab0be9e78af)
- 등록된 즐겨찾기가 없을 때 예외 메시지를 출력합니다.

## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리


## 📂 테스트 방법
- 지도 페이지에서 테스트
- npm run build 통과

## 💬 기타 참고 사항

