### PR TITLE
프로필 변경 API연결

### DIFF
--- a/src/components/Setting/ProfileInfoSection.tsx
+++ b/src/components/Setting/ProfileInfoSection.tsx
@@ -1,27 +1,20 @@
-import { Gender, MBTI, UserInfo } from "@/stores/useAuthStore";
+import { UserInfo } from "@/stores/useAuthStore";
 import FormFieldRow from "./FormFieldRow";
 import BaseButton from "../common/Button/BaseButton";
 import DateInput from "../common/Input/DateInput";
 import GenderRadioGroup from "./GenderRadioGroup";
-import { useState } from "react";
 import MbtiSelect from "./MbtiSelectBox";
+import useProfileInfoSection from "./useProfileInfoSection";
 
 interface ProfileInfoSectionProp {
   user: UserInfo;
 }
 
 const ProfileInfoSection = ({ user }: ProfileInfoSectionProp) => {
-  const [userInfo, setUserInfo] = useState<{
-    birthday: string;
-    liveAloneDate: string;
-    gender?: Gender;
-    mbti?: MBTI;
-  }>({
-    birthday: user.birthday ?? "",
-    liveAloneDate: user.liveAloneDate ?? "",
-    gender: user.gender,
-    mbti: user.mbti,
+  const { userInfo, errors, handleChange, handleSave } = useProfileInfoSection({
+    user,
   });
+
   return (
     <section className="flex flex-col border rounded-sm px-4 py-6 gap-6">
       <h2 className="text-lg font-bold">프로필 정보</h2>
@@ -30,10 +23,10 @@ const ProfileInfoSection = ({ user }: ProfileInfoSectionProp) => {
           <DateInput
             size="xl"
             fullWidth={false}
+            styleState={errors.birthday ? "invalid" : "default"}
+            error={errors.birthday}
             value={userInfo.birthday}
-            onChange={(value) =>
-              setUserInfo((prev) => ({ ...prev, birthday: value }))
-            }
+            onChange={(value) => handleChange("birthday", value)}
             className="w-80"
           />
         </FormFieldRow>
@@ -41,27 +34,23 @@ const ProfileInfoSection = ({ user }: ProfileInfoSectionProp) => {
           <DateInput
             size="xl"
             fullWidth={false}
+            styleState={errors.liveAloneDate ? "invalid" : "default"}
+            error={errors.liveAloneDate}
             value={userInfo.liveAloneDate}
-            onChange={(value) =>
-              setUserInfo((prev) => ({ ...prev, liveAloneDate: value }))
-            }
+            onChange={(value) => handleChange("liveAloneDate", value)}
             className="w-80"
           />
         </FormFieldRow>
         <FormFieldRow label="성별">
           <GenderRadioGroup
             value={userInfo.gender}
-            onChange={(selected) =>
-              setUserInfo((prev) => ({ ...prev, gender: selected }))
-            }
+            onChange={(selected) => handleChange("gender", selected)}
           />
         </FormFieldRow>
         <FormFieldRow label="MBTI">
           <MbtiSelect
             value={userInfo.mbti}
-            onChange={(value) =>
-              setUserInfo((prev) => ({ ...prev, mbti: value }))
-            }
+            onChange={(value) => handleChange("mbti", value)}
           />
         </FormFieldRow>
       </ul>
@@ -70,6 +59,7 @@ const ProfileInfoSection = ({ user }: ProfileInfoSectionProp) => {
         variant="filled"
         color="violet800"
         className="w-6/12 items-center mx-auto"
+        onClick={handleSave}
       >
         프로필 변경
       </BaseButton>

--- a/src/components/Setting/ProfileInfoSection.tsx
+++ b/src/components/Setting/ProfileInfoSection.tsx
@@ -11,9 +11,10 @@ interface ProfileInfoSectionProp {
 }
 
 const ProfileInfoSection = ({ user }: ProfileInfoSectionProp) => {
-  const { userInfo, errors, handleChange, handleSave } = useProfileInfoSection({
-    user,
-  });
+  const { userInfo, isLoading, errors, handleChange, handleSave } =
+    useProfileInfoSection({
+      user,
+    });
 
   return (
     <section className="flex flex-col border rounded-sm px-4 py-6 gap-6">
@@ -59,6 +60,7 @@ const ProfileInfoSection = ({ user }: ProfileInfoSectionProp) => {
         variant="filled"
         color="violet800"
         className="w-6/12 items-center mx-auto"
+        isLoading={isLoading}
         onClick={handleSave}
       >
         프로필 변경

--- a/src/components/Setting/ProfileInfoSection.tsx
+++ b/src/components/Setting/ProfileInfoSection.tsx
@@ -5,6 +5,7 @@ import DateInput from "../common/Input/DateInput";
 import GenderRadioGroup from "./GenderRadioGroup";
 import MbtiSelect from "./MbtiSelectBox";
 import useProfileInfoSection from "./useProfileInfoSection";
+import { convertDashToDot } from "@/utils/date";
 
 interface ProfileInfoSectionProp {
   user: UserInfo;
@@ -26,7 +27,7 @@ const ProfileInfoSection = ({ user }: ProfileInfoSectionProp) => {
             fullWidth={false}
             styleState={errors.birthday ? "invalid" : "default"}
             error={errors.birthday}
-            value={userInfo.birthday}
+            value={convertDashToDot(userInfo.birthday)}
             onChange={(value) => handleChange("birthday", value)}
             className="w-80"
           />
@@ -37,7 +38,7 @@ const ProfileInfoSection = ({ user }: ProfileInfoSectionProp) => {
             fullWidth={false}
             styleState={errors.liveAloneDate ? "invalid" : "default"}
             error={errors.liveAloneDate}
-            value={userInfo.liveAloneDate}
+            value={convertDashToDot(userInfo.liveAloneDate)}
             onChange={(value) => handleChange("liveAloneDate", value)}
             className="w-80"
           />

--- a/src/components/Setting/useProfileInfoSection.ts
+++ b/src/components/Setting/useProfileInfoSection.ts
@@ -16,6 +16,7 @@ interface FormError {
 }
 
 const useProfileInfoSection = ({ user }: UseProfileInfoSectionProp) => {
+  const [isLoading, setIsLoading] = useState(false);
   const [errors, setErrors] = useState<FormError>({});
   const { setUser } = useAuthStore();
   const [userInfo, setUserInfo] = useState<{
@@ -65,6 +66,8 @@ const useProfileInfoSection = ({ user }: UseProfileInfoSectionProp) => {
   const handleSave = async () => {
     if (!validateForm()) return;
 
+    setIsLoading(true);
+
     try {
       const item: UpdateProfileParams = {
         birthday: convertDotToDash(userInfo.birthday),
@@ -93,10 +96,12 @@ const useProfileInfoSection = ({ user }: UseProfileInfoSectionProp) => {
           ? error.message
           : "프로필 업데이트가 실패하였습니다.";
       showToastMessage({ type: "error", message: errorMessage });
+    } finally {
+      setIsLoading(false);
     }
   };
 
-  return { userInfo, errors, handleChange, handleSave };
+  return { userInfo, isLoading, errors, handleChange, handleSave };
 };
 
 export default useProfileInfoSection;

--- a/src/components/Setting/useProfileInfoSection.ts
+++ b/src/components/Setting/useProfileInfoSection.ts
@@ -44,7 +44,22 @@ const useProfileInfoSection = ({ user }: UseProfileInfoSectionProp) => {
     }
   };
 
+  const validateForm = useCallback(() => {
+    const newErrors: FormError = {};
+
+    const birthdayError = validateDateInput(userInfo.birthday);
+    if (birthdayError) newErrors.birthday = birthdayError;
+
+    const liveAloneDateError = validateDateInput(userInfo.liveAloneDate);
+    if (liveAloneDateError) newErrors.liveAloneDate = liveAloneDateError;
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }, [userInfo.birthday, userInfo.liveAloneDate]);
+
   const handleSave = async () => {
+    console.log(userInfo);
+    if (!validateForm()) return;
     console.log(userInfo);
   };
 

--- a/src/components/Setting/useProfileInfoSection.ts
+++ b/src/components/Setting/useProfileInfoSection.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { Gender, MBTI, UserInfo } from "@/stores/useAuthStore";
+import { validateDateInput } from "@/utils/date";
+import { useCallback, useState } from "react";
+
+interface UseProfileInfoSectionProp {
+  user: UserInfo;
+}
+
+interface FormError {
+  birthday?: string;
+  liveAloneDate?: string;
+}
+
+const useProfileInfoSection = ({ user }: UseProfileInfoSectionProp) => {
+  const [errors, setErrors] = useState<FormError>({});
+  const [userInfo, setUserInfo] = useState<{
+    birthday: string;
+    liveAloneDate: string;
+    gender?: Gender;
+    mbti?: MBTI;
+  }>({
+    birthday: user.birthday ?? "",
+    liveAloneDate: user.liveAloneDate ?? "",
+    gender: user.gender,
+    mbti: user.mbti,
+  });
+
+  const handleChange = <T extends keyof typeof userInfo>(
+    key: T,
+    value: (typeof userInfo)[T],
+  ) => {
+    setUserInfo((prev) => ({ ...prev, [key]: value }));
+
+    if (key === "birthday" && typeof value === "string") {
+      if (!validateDateInput(value))
+        setErrors((prev) => ({ ...prev, birthday: "" }));
+    }
+
+    if (key === "liveAloneDate" && typeof value === "string") {
+      if (!validateDateInput(value))
+        setErrors((prev) => ({ ...prev, liveAloneDate: "" }));
+    }
+  };
+
+  const handleSave = async () => {
+    console.log(userInfo);
+  };
+
+  return { userInfo, errors, handleChange, handleSave };
+};
+
+export default useProfileInfoSection;

--- a/src/components/common/Input/DateInput.tsx
+++ b/src/components/common/Input/DateInput.tsx
@@ -15,10 +15,18 @@ export type DateInputProps = Omit<
 
 const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
   ({ value, onChange, ...props }, ref) => {
-    const [inputValue, setInputValue] = useState(formatDate(value));
+    const [inputValue, setInputValue] = useState(value);
 
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const formatted = formatDate(e.target.value);
+      const rawValue = e.target.value;
+
+      const cleaned = rawValue.replace(/\D/g, "").slice(0, 8);
+      setInputValue(cleaned);
+      onChange(cleaned);
+    };
+
+    const handleBlur = () => {
+      const formatted = formatDate(inputValue);
       setInputValue(formatted);
       onChange(formatted);
     };
@@ -34,6 +42,7 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
         value={inputValue}
         placeholder="1990.01.01"
         onChange={handleInputChange}
+        onBlur={handleBlur}
       />
     );
   },

--- a/src/lib/api/profile.ts
+++ b/src/lib/api/profile.ts
@@ -50,3 +50,17 @@ export const updateNickname = async (
     body: JSON.stringify({ newNickname: nickname }),
   });
 };
+
+export interface UpdateProfileParams {
+  birthday?: string;
+  liveAloneDate?: string;
+  gender?: string;
+  mbti?: string;
+}
+export const updateProfile = async (params: UpdateProfileParams) => {
+  return await client("/users/me/profile", {
+    method: "PATCH",
+    needAuth: true,
+    body: JSON.stringify(params),
+  });
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -5,6 +5,9 @@ import {
   differenceInWeeks,
   formatDistanceToNow,
   format,
+  parse,
+  isValid,
+  isAfter,
 } from "date-fns";
 import { ko } from "date-fns/locale";
 import { toZonedTime, format as fnsTzFormat } from "date-fns-tz";
@@ -105,4 +108,31 @@ export const formatDate = (val: string): string => {
   }
 
   return parts.join(".");
+};
+
+/**
+ * 날짜 문자열 유효성 검사
+ * - 형식이 yyyy.MM.dd 인지 확인
+ * - 존재하지 않는 날짜(ex. 2023.02.30 등)인지 확인
+ * - 오늘보다 미래 날짜인지 확인
+ *
+ * @param dateStr 사용자 입력 날짜 문자열
+ * @returns 오류 메시지 (유효하면 null 반환)
+ */
+export const validateDateInput = (dateStr: string): string | null => {
+  const dateRegex = /^\d{4}\.(0[1-9]|1[0-2])\.(0[1-9]|[12]\d|3[01])$/;
+  if (!dateRegex.test(dateStr)) {
+    return "날짜 형식이 올바르지 않습니다. 예: 1990.01.01";
+  }
+
+  const parsedDate = parse(dateStr, "yyyy.MM.dd", new Date());
+  if (!isValid(parsedDate)) {
+    return "존재하지 않는 날짜입니다.";
+  }
+
+  if (isAfter(parsedDate, new Date())) {
+    return "미래 날짜는 입력할 수 없습니다.";
+  }
+
+  return null;
 };

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -120,12 +120,13 @@ export const formatDate = (val: string): string => {
  * @returns 오류 메시지 (유효하면 null 반환)
  */
 export const validateDateInput = (dateStr: string): string | null => {
+  const dateString = convertDashToDot(dateStr);
   const dateRegex = /^\d{4}\.(0[1-9]|1[0-2])\.(0[1-9]|[12]\d|3[01])$/;
-  if (!dateRegex.test(dateStr)) {
+  if (!dateRegex.test(dateString)) {
     return "날짜 형식이 올바르지 않습니다. 예: 1990.01.01";
   }
 
-  const parsedDate = parse(dateStr, "yyyy.MM.dd", new Date());
+  const parsedDate = parse(dateString, "yyyy.MM.dd", new Date());
   if (!isValid(parsedDate)) {
     return "존재하지 않는 날짜입니다.";
   }


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
프로필 변경 API연결했습니다.

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 생년월일, 자취 일자의 형식이 yyyy.MM.dd 형식이 아니거나 미래이거나 이상한 날짜의 경우 오류를 출력하도록했습니다.
- 프로필 변경 API를 연결했습니다.
- UI상으론 ".", 서버에 전송할 때는 "-"형태로 보내야해서 형식을 변경하는 로직을 추가했습니다.
- 데이터 업데이트가 성공할경우 useAuth에도 반영이 되도록 했습니다.


## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
<img width="845" alt="스크린샷 2025-06-10 오전 11 29 20" src="https://github.com/user-attachments/assets/0941b94d-086b-4004-8c1c-6335703a0c84" />



## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->



## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
