### PR TITLE
비밀번호 변경 API 연결

### DIFF
--- a/src/components/Setting/ProfileChangePassword.tsx
+++ b/src/components/Setting/ProfileChangePassword.tsx
@@ -4,7 +4,14 @@ import FormFieldRow from "./FormFieldRow";
 import useProfileChangePassword from "./useProfileChangePassword";
 
 const ProfileChangePassword = () => {
-  const { formState, handleFormChange, errors } = useProfileChangePassword();
+  const {
+    formState,
+    isLoading,
+    errors,
+    handleFormChange,
+
+    handleChangePassword,
+  } = useProfileChangePassword();
   return (
     <section className="flex flex-col border rounded-sm px-4 py-6 gap-6">
       <h2 className="text-lg font-bold">비밀번호 변경</h2>
@@ -47,7 +54,9 @@ const ProfileChangePassword = () => {
         size="xl"
         variant="filled"
         color="violet800"
+        isLoading={isLoading}
         className="w-6/12 items-center mx-auto"
+        onClick={handleChangePassword}
       >
         비밀번호 변경
       </BaseButton>

--- a/src/components/Setting/useProfileChangePassword.ts
+++ b/src/components/Setting/useProfileChangePassword.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { changePassword } from "@/lib/api/profile";
+import { useToastMessageContext } from "@/providers/ToastMessageProvider";
 import { validatePassword } from "@/utils/validate";
 import { ChangeEvent, FormEvent, useCallback, useState } from "react";
 
@@ -18,6 +20,8 @@ const useProfileChangePassword = () => {
   });
 
   const [errors, setErrors] = useState<ChangePasswordFormErrors>({});
+
+  const { showToastMessage } = useToastMessageContext();
 
   const validateForm = useCallback(() => {
     const newErrors: ChangePasswordFormErrors = {};
@@ -53,6 +57,22 @@ const useProfileChangePassword = () => {
     e.preventDefault();
 
     if (!validateForm()) return;
+    try {
+      await changePassword({
+        currentPassword: formState.currentPassword,
+        newPassword: formState.newPassword,
+      });
+      showToastMessage({
+        type: "success",
+        message: "비밀번호 변경에 성공했습니다.",
+      });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "비밀번호 변경에 실패했습니다.";
+      showToastMessage({ type: "error", message: errorMessage });
+    }
   };
 
   return { formState, errors, handleFormChange, handleChangePassword };

--- a/src/components/Setting/useProfileChangePassword.ts
+++ b/src/components/Setting/useProfileChangePassword.ts
@@ -69,6 +69,11 @@ const useProfileChangePassword = () => {
         type: "success",
         message: "비밀번호 변경에 성공했습니다.",
       });
+      setFormState({
+        currentPassword: "",
+        newPassword: "",
+        confirmPassword: "",
+      });
     } catch (error) {
       const errorMessage =
         error instanceof Error

--- a/src/components/Setting/useProfileChangePassword.ts
+++ b/src/components/Setting/useProfileChangePassword.ts
@@ -19,6 +19,7 @@ const useProfileChangePassword = () => {
     confirmPassword: "",
   });
 
+  const [isLoading, setIsLoading] = useState(false);
   const [errors, setErrors] = useState<ChangePasswordFormErrors>({});
 
   const { showToastMessage } = useToastMessageContext();
@@ -57,6 +58,8 @@ const useProfileChangePassword = () => {
     e.preventDefault();
 
     if (!validateForm()) return;
+
+    setIsLoading(true);
     try {
       await changePassword({
         currentPassword: formState.currentPassword,
@@ -72,10 +75,18 @@ const useProfileChangePassword = () => {
           ? error.message
           : "비밀번호 변경에 실패했습니다.";
       showToastMessage({ type: "error", message: errorMessage });
+    } finally {
+      setIsLoading(false);
     }
   };
 
-  return { formState, errors, handleFormChange, handleChangePassword };
+  return {
+    formState,
+    isLoading,
+    errors,
+    handleFormChange,
+    handleChangePassword,
+  };
 };
 
 export default useProfileChangePassword;

--- a/src/lib/api/profile.ts
+++ b/src/lib/api/profile.ts
@@ -58,3 +58,18 @@ export const withdrawUser = async (reason: string): Promise<void> => {
     body: JSON.stringify({ reason }),
   });
 };
+
+interface ChangePasswordParams {
+  currentPassword: string;
+  newPassword: string;
+}
+
+export const changePassword = async (
+  param: ChangePasswordParams,
+): Promise<void> => {
+  return await client("/users/me/password", {
+    method: "PATCH",
+    needAuth: true,
+    body: JSON.stringify(param),
+  });
+};


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
비밀번호 변경 API 연결

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 비밀번호 변경 API를 연결했습니다.
- 비밀번호 변경 완료 후 입력했던 비밀번호 폼들이 공백으로 다시 변경되도록 했습니다.


## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
|비밀번호 변경 성공|비밀번호 변경 실패|
|--|--|
|<img width="748" alt="스크린샷 2025-06-10 오전 11 59 40" src="https://github.com/user-attachments/assets/13b63514-80e7-4423-b1de-6ffef9404d1f" />|<img width="865" alt="스크린샷 2025-06-10 오전 11 59 53" src="https://github.com/user-attachments/assets/88736df5-aebe-4e7d-9e7c-e6c8281087f1" />|



## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->
비밀번호 변경 후 로그인 페이지에서 변경된 비밀번호를 통해 정상적으로 로그인 되는 것 확인했습니다.

## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
