### PR TITLE
Feat/marker 등록되어있는 장소들 마커 표시, 내 위치 기반 행정동 이름 업데이트 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "eslint-config-prettier": "^10.1.2",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "kakao.maps.d.ts": "^0.1.40",
         "postcss": "^8.5.3",
         "prettier": "^3.5.3",
         "tailwindcss": "3.4.1",
@@ -4453,6 +4454,13 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.40.tgz",
+      "integrity": "sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/keen-slider": {
       "version": "6.8.6",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-config-prettier": "^10.1.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "kakao.maps.d.ts": "^0.1.40",
     "postcss": "^8.5.3",
     "prettier": "^3.5.3",
     "tailwindcss": "3.4.1",

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -1,14 +1,19 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { addMarkers, initializeMap, loadKakaoMapSdk, moveMyLocation } from "@/utils/mapUtil";
-import { useMapStore } from "@/stores/mapStore";
+import { useEffect, useRef, useState } from "react";
+import {
+  addMarkers, enableClickToShowAddress,
+  initializeMap,
+  loadKakaoMapSdk,
+  moveMyLocation, updateCenterAddress,
+} from "@/utils/mapUtil";
+import { useMapStore } from "@/stores/mapStore"; // 지도 좌측상단에 지도 중심좌표에 대한 주소정보를 표출하는 함수입니다
 
 export default function KakaoMap() {
   const mapRef = useRef<HTMLDivElement>(null);
   const myLocation = useMapStore((state) => state.myLocation);
   const { setMyLocation } = useMapStore();
-
+  const [centerAddr, setCenterAddr] = useState("");
 
   useEffect(() => {
     loadKakaoMapSdk(() => {
@@ -16,19 +21,25 @@ export default function KakaoMap() {
       initializeMap(mapRef.current, (map) => {
         addMarkers(map); // 마커 추가 테스트
         moveMyLocation(map, setMyLocation); // 내 위치 추적하여 전역상태변수에 위도경도 저장
+        updateCenterAddress(map, setCenterAddr); // 지도 중심 주소 업데이트
+        enableClickToShowAddress(map);           // 클릭 시 주소 표시
       });
     });
   }, []);
-
 
   useEffect(() => {
     console.log("전역상태 myLocation :", myLocation);
   }, [myLocation]);
 
-
   return (
     <>
       <div ref={mapRef} className="absolute w-screen h-screen left-0" />
+      <div
+        id="centerAddr"
+        className="absolute top-2 left-2 bg-white text-sm px-3 py-1 rounded shadow z-50 left-40 top-40"
+      >야호야홍
+        {centerAddr || "중심 좌표의 주소를 불러오는 중..."}
+      </div>
     </>
   );
 }

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -1,118 +1,18 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { initializeMap, loadKakaoMapSdk } from "@/utils/mapUtil";
-
-// Kakao 객체를 전역 선언합니다.
-// declare global {
-//   interface Window {
-//     kakao: {
-//       maps: {
-//         LatLng: new (lat: number, lng: number) => void;
-//         Map: new (
-//           container: HTMLElement,
-//           options: { center: void; level: number },
-//         ) => void;
-//         load: (callback: () => void) => void;
-//       };
-//     };
-//   }
-// }
-declare global {
-  interface Window {
-    kakao: any; // kakao.maps.* 전부 포괄
-  }
-}
-
-// 키워드 검색 완료 시 호출되는 콜백함수 입니다
-// function placesSearchCB(data, status, pagination) {
-//   if (status === kakao.maps.services.Status.OK) {
-//     // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
-//     // LatLngBounds 객체에 좌표를 추가합니다
-//     const bounds = new kakao.maps.LatLngBounds();
-//
-//     for (let i = 0; i < data.length; i++) {
-//       displayMarker(data[i]);
-//       bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
-//     }
-//
-//     // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
-//     map.setBounds(bounds);
-//   }
-// }
-
-// 지도에 마커를 표시하는 함수입니다
-// function displayMarker(place) {
-//   // 마커를 생성하고 지도에 표시합니다
-//   const marker = new kakao.maps.Marker({
-//     map: map,
-//     position: new kakao.maps.LatLng(place.y, place.x),
-//   });
-//
-//   // 마커에 클릭이벤트를 등록합니다
-//   kakao.maps.event.addListener(marker, "click", function () {
-//     // 마커를 클릭하면 장소명이 인포윈도우에 표출됩니다
-//     infowindow.setContent(
-//       '<div style="padding:5px;font-size:12px;height:50px;">' +
-//         place.place_name +
-//         "placeId: " +
-//         place.id +
-//         "</div>",
-//     );
-//     infowindow.open(map, marker);
-//   });
-// }
-
-// function createMap() {
-//   const KAKAO_MAP_API_KEY = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID; // 카카오지도 api
-//
-//   const mapRef = useRef<HTMLDivElement>(null);
-//   const script = document.createElement("script");
-//   script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_MAP_API_KEY}&autoload=false&libraries=services`;
-//   script.async = true;
-//
-//   script.onload = () => {
-//     if (!window.kakao || !window.kakao.maps) return;
-//
-//     const kakao = window.kakao;
-//
-//     window.kakao.maps.load(() => {
-//       const container = mapRef.current;
-//       if (!container) return;
-//
-//       // 내 위치 기준으로 지도를 불러옴
-//       navigator.geolocation.getCurrentPosition((position) => {
-//         const lat = position.coords.latitude;
-//         const lng = position.coords.longitude;
-//         const userLocation = new window.kakao.maps.LatLng(lat, lng);
-//
-//         const map = new window.kakao.maps.Map(container, {
-//           center: userLocation,
-//           level: 3,
-//         });
-//
-//         // 장소 검색 객체를 생성합니다
-//         // const ps = new kakao.maps.services.Places();
-//
-//         // 키워드로 장소를 검색합니다
-//         // ps.keywordSearch("동현피트니스", placesSearchCB);
-//       });
-//       document.head.appendChild(script);
-//     });
-//   };
-//   return mapRef;
-// }
-
-
+import { addMarkers, initializeMap, loadKakaoMapSdk } from "@/utils/mapUtil";
 
 export default function KakaoMap() {
   const mapRef = useRef<HTMLDivElement>(null);
 
+
   useEffect(() => {
     loadKakaoMapSdk(() => {
-      if (mapRef.current) {
-        initializeMap(mapRef.current);
-      }
+      if (!mapRef.current) return;
+      initializeMap(mapRef.current, (map) => {
+        addMarkers(map); // ✅ 외부 함수 호출만으로 마커 표시
+      });
     });
   }, []);
 

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -12,7 +12,7 @@ import { useMapStore } from "@/stores/mapStore"; // 지도 좌측상단에 지�
 export default function KakaoMap() {
   const mapRef = useRef<HTMLDivElement>(null);
   const myLocation = useMapStore((state) => state.myLocation);
-  const { setMyLocation } = useMapStore();
+  const { setMyLocation, setRegionName } = useMapStore();
   const [centerAddr, setCenterAddr] = useState("");
 
   useEffect(() => {
@@ -21,8 +21,8 @@ export default function KakaoMap() {
       initializeMap(mapRef.current, (map) => {
         addMarkers(map); // 마커 추가 테스트
         moveMyLocation(map, setMyLocation); // 내 위치 추적하여 전역상태변수에 위도경도 저장
-        updateCenterAddress(map, setCenterAddr); // 지도 중심 주소 업데이트
-        enableClickToShowAddress(map);           // 클릭 시 주소 표시
+        updateCenterAddress(map, setRegionName ,setCenterAddr); // 지도 중심 주소 업데이트 및 내 위치 행정동 저장
+        enableClickToShowAddress(map); // 클릭 시 주소 표시
       });
     });
   }, []);
@@ -37,7 +37,7 @@ export default function KakaoMap() {
       <div
         id="centerAddr"
         className="absolute top-2 left-2 bg-white text-sm px-3 py-1 rounded shadow z-50 left-40 top-40"
-      >야호야홍
+      >
         {centerAddr || "중심 좌표의 주소를 불러오는 중..."}
       </div>
     </>

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -5,14 +5,14 @@ import {
   addMarkers,
   initializeMap,
   loadKakaoMapSdk,
-  moveMyLocation,
+  moveMyLocation, placeToMarker,
   updateCenterAddress,
 } from "@/utils/mapUtil";
-import { useMapStore } from "@/stores/mapStore"; // 지도 좌측상단에 지도 중심좌표에 대한 주소정보를 표출하는 함수입니다
+import { useMapStore } from "@/stores/mapStore";
 
 export default function KakaoMap() {
   const mapRef = useRef<HTMLDivElement>(null);
-  const myLocation = useMapStore((state) => state.myLocation);
+  const { placeList } = useMapStore((state) => state);
   const { setMyLocation, setRegionName } = useMapStore();
 
   useEffect(() => {
@@ -22,13 +22,10 @@ export default function KakaoMap() {
         addMarkers(map); // 마커 추가 테스트
         moveMyLocation(map, setMyLocation); // 내 위치 추적하여 전역상태변수에 위도경도 저장
         updateCenterAddress(map, setRegionName); // 지도 중심 주소 업데이트 및 내 위치 행정동 저장
+        placeToMarker(placeList!, map);
       });
     });
   }, []);
-
-  useEffect(() => {
-    console.log("전역상태 myLocation :", myLocation);
-  }, [myLocation]);
 
   return (
     <>

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -1,20 +1,34 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { addMarkers, initializeMap, loadKakaoMapSdk } from "@/utils/mapUtil";
+import { addMarkers, initializeMap, loadKakaoMapSdk, moveMyLocation } from "@/utils/mapUtil";
+import { useMapStore } from "@/stores/mapStore";
 
 export default function KakaoMap() {
   const mapRef = useRef<HTMLDivElement>(null);
+  const myLocation = useMapStore((state) => state.myLocation);
+  const { setMyLocation } = useMapStore();
 
 
   useEffect(() => {
     loadKakaoMapSdk(() => {
       if (!mapRef.current) return;
       initializeMap(mapRef.current, (map) => {
-        addMarkers(map); // ✅ 외부 함수 호출만으로 마커 표시
+        addMarkers(map); // 마커 추가 테스트
+        moveMyLocation(map, setMyLocation); // 내 위치 추적하여 전역상태변수에 위도경도 저장
       });
     });
   }, []);
 
-  return <div ref={mapRef} className="absolute w-screen h-screen left-0" />;
+
+  useEffect(() => {
+    console.log("전역상태 myLocation :", myLocation);
+  }, [myLocation]);
+
+
+  return (
+    <>
+      <div ref={mapRef} className="absolute w-screen h-screen left-0" />
+    </>
+  );
 }

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -12,20 +12,35 @@ import { useMapStore } from "@/stores/mapStore";
 
 export default function KakaoMap() {
   const mapRef = useRef<HTMLDivElement>(null);
-  const { placeList } = useMapStore((state) => state);
-  const { setMyLocation, setRegionName } = useMapStore();
+  const { placeList, myLocation } = useMapStore((state) => state);
+  const { setMyLocation, setRegionName, setPlaceList } = useMapStore();
+
+  const mapInstanceRef = useRef<any>(null);
 
   useEffect(() => {
     loadKakaoMapSdk(() => {
       if (!mapRef.current) return;
       initializeMap(mapRef.current, (map) => {
+        mapInstanceRef.current = map;
+
         addMarkers(map); // 마커 추가 테스트
         moveMyLocation(map, setMyLocation); // 내 위치 추적하여 전역상태변수에 위도경도 저장
         updateCenterAddress(map, setRegionName); // 지도 중심 주소 업데이트 및 내 위치 행정동 저장
-        placeToMarker(placeList!, map);
       });
     });
   }, []);
+
+  // 내 위치가 바뀔 때마다 placeList가 갱신
+  // 만약 인근에 조회된 장소가 없다면 null로 초기화
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+
+    if(placeList == null) {
+      setPlaceList(null);
+    }
+
+    placeToMarker(placeList!, map);
+  }, [myLocation]);
 
   return (
     <>

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef } from "react";
 import {
-  addMarkers,
   initializeMap,
   loadKakaoMapSdk,
   moveMyLocation, placeToMarker,
@@ -15,15 +14,13 @@ export default function KakaoMap() {
   const { placeList, myLocation } = useMapStore((state) => state);
   const { setMyLocation, setRegionName, setPlaceList } = useMapStore();
 
-  const mapInstanceRef = useRef<any>(null);
+  const mapInstanceRef = useRef<unknown>(null);
 
   useEffect(() => {
     loadKakaoMapSdk(() => {
       if (!mapRef.current) return;
       initializeMap(mapRef.current, (map) => {
         mapInstanceRef.current = map;
-
-        addMarkers(map); // 마커 추가 테스트
         moveMyLocation(map, setMyLocation); // 내 위치 추적하여 전역상태변수에 위도경도 저장
         updateCenterAddress(map, setRegionName); // 지도 중심 주소 업데이트 및 내 위치 행정동 저장
       });

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import {
-  addMarkers, enableClickToShowAddress,
+  addMarkers,
   initializeMap,
   loadKakaoMapSdk,
-  moveMyLocation, updateCenterAddress,
+  moveMyLocation,
+  updateCenterAddress,
 } from "@/utils/mapUtil";
 import { useMapStore } from "@/stores/mapStore"; // 지도 좌측상단에 지도 중심좌표에 대한 주소정보를 표출하는 함수입니다
 
@@ -13,7 +14,6 @@ export default function KakaoMap() {
   const mapRef = useRef<HTMLDivElement>(null);
   const myLocation = useMapStore((state) => state.myLocation);
   const { setMyLocation, setRegionName } = useMapStore();
-  const [centerAddr, setCenterAddr] = useState("");
 
   useEffect(() => {
     loadKakaoMapSdk(() => {
@@ -21,8 +21,7 @@ export default function KakaoMap() {
       initializeMap(mapRef.current, (map) => {
         addMarkers(map); // 마커 추가 테스트
         moveMyLocation(map, setMyLocation); // 내 위치 추적하여 전역상태변수에 위도경도 저장
-        updateCenterAddress(map, setRegionName ,setCenterAddr); // 지도 중심 주소 업데이트 및 내 위치 행정동 저장
-        enableClickToShowAddress(map); // 클릭 시 주소 표시
+        updateCenterAddress(map, setRegionName); // 지도 중심 주소 업데이트 및 내 위치 행정동 저장
       });
     });
   }, []);
@@ -34,12 +33,6 @@ export default function KakaoMap() {
   return (
     <>
       <div ref={mapRef} className="absolute w-screen h-screen left-0" />
-      <div
-        id="centerAddr"
-        className="absolute top-2 left-2 bg-white text-sm px-3 py-1 rounded shadow z-50 left-40 top-40"
-      >
-        {centerAddr || "중심 좌표의 주소를 불러오는 중..."}
-      </div>
     </>
   );
 }

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -1,184 +1,120 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { initializeMap, loadKakaoMapSdk } from "@/utils/mapUtil";
 
 // Kakao 객체를 전역 선언합니다.
-declare global {
-  interface Window {
-    kakao: {
-      maps: {
-        LatLng: new (lat: number, lng: number) => void;
-        Map: new (
-          container: HTMLElement,
-          options: { center: void; level: number },
-        ) => void;
-        load: (callback: () => void) => void;
-      };
-    };
-  }
-}
 // declare global {
 //   interface Window {
-//     kakao: any; // kakao.maps.* 전부 포괄
+//     kakao: {
+//       maps: {
+//         LatLng: new (lat: number, lng: number) => void;
+//         Map: new (
+//           container: HTMLElement,
+//           options: { center: void; level: number },
+//         ) => void;
+//         load: (callback: () => void) => void;
+//       };
+//     };
+//   }
+// }
+declare global {
+  interface Window {
+    kakao: any; // kakao.maps.* 전부 포괄
+  }
+}
+
+// 키워드 검색 완료 시 호출되는 콜백함수 입니다
+// function placesSearchCB(data, status, pagination) {
+//   if (status === kakao.maps.services.Status.OK) {
+//     // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
+//     // LatLngBounds 객체에 좌표를 추가합니다
+//     const bounds = new kakao.maps.LatLngBounds();
+//
+//     for (let i = 0; i < data.length; i++) {
+//       displayMarker(data[i]);
+//       bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
+//     }
+//
+//     // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
+//     map.setBounds(bounds);
 //   }
 // }
 
-export default function KakaoMap() {
-  const KAKAO_MAP_API_KEY = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID; // 카카오지도 api
+// 지도에 마커를 표시하는 함수입니다
+// function displayMarker(place) {
+//   // 마커를 생성하고 지도에 표시합니다
+//   const marker = new kakao.maps.Marker({
+//     map: map,
+//     position: new kakao.maps.LatLng(place.y, place.x),
+//   });
+//
+//   // 마커에 클릭이벤트를 등록합니다
+//   kakao.maps.event.addListener(marker, "click", function () {
+//     // 마커를 클릭하면 장소명이 인포윈도우에 표출됩니다
+//     infowindow.setContent(
+//       '<div style="padding:5px;font-size:12px;height:50px;">' +
+//         place.place_name +
+//         "placeId: " +
+//         place.id +
+//         "</div>",
+//     );
+//     infowindow.open(map, marker);
+//   });
+// }
 
+// function createMap() {
+//   const KAKAO_MAP_API_KEY = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID; // 카카오지도 api
+//
+//   const mapRef = useRef<HTMLDivElement>(null);
+//   const script = document.createElement("script");
+//   script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_MAP_API_KEY}&autoload=false&libraries=services`;
+//   script.async = true;
+//
+//   script.onload = () => {
+//     if (!window.kakao || !window.kakao.maps) return;
+//
+//     const kakao = window.kakao;
+//
+//     window.kakao.maps.load(() => {
+//       const container = mapRef.current;
+//       if (!container) return;
+//
+//       // 내 위치 기준으로 지도를 불러옴
+//       navigator.geolocation.getCurrentPosition((position) => {
+//         const lat = position.coords.latitude;
+//         const lng = position.coords.longitude;
+//         const userLocation = new window.kakao.maps.LatLng(lat, lng);
+//
+//         const map = new window.kakao.maps.Map(container, {
+//           center: userLocation,
+//           level: 3,
+//         });
+//
+//         // 장소 검색 객체를 생성합니다
+//         // const ps = new kakao.maps.services.Places();
+//
+//         // 키워드로 장소를 검색합니다
+//         // ps.keywordSearch("동현피트니스", placesSearchCB);
+//       });
+//       document.head.appendChild(script);
+//     });
+//   };
+//   return mapRef;
+// }
+
+
+
+export default function KakaoMap() {
   const mapRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const script = document.createElement("script");
-    script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_MAP_API_KEY}&autoload=false&libraries=services`;
-    script.async = true;
-
-    script.onload = () => {
-      if (!window.kakao || !window.kakao.maps) return;
-
-      // const kakao = window.kakao;
-
-      window.kakao.maps.load(() => {
-        const container = mapRef.current;
-        if (!container) return;
-
-        navigator.geolocation.getCurrentPosition((position) => {
-          const lat = position.coords.latitude;
-          const lng = position.coords.longitude;
-          const userLocation = new window.kakao.maps.LatLng(lat, lng);
-
-          new window.kakao.maps.Map(container, {
-            center: userLocation,
-            level: 3,
-          });
-
-        //   // 마커를 클릭하면 장소명을 표출할 인포윈도우 입니다
-        //   const infowindow = new kakao.maps.InfoWindow({ zIndex: 1 });
-        //
-        //   // 장소 검색 객체를 생성합니다
-        //   const ps = new kakao.maps.services.Places();
-        //
-        //   // 키워드로 장소를 검색합니다
-        //   ps.keywordSearch("동현피트니스", placesSearchCB);
-        //
-        //   // 키워드 검색 완료 시 호출되는 콜백함수 입니다
-        //   function placesSearchCB(data, status, pagination) {
-        //     if (status === kakao.maps.services.Status.OK) {
-        //       // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
-        //       // LatLngBounds 객체에 좌표를 추가합니다
-        //       const bounds = new kakao.maps.LatLngBounds();
-        //
-        //       for (let i = 0; i < data.length; i++) {
-        //         displayMarker(data[i]);
-        //         bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
-        //       }
-        //
-        //       // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
-        //       map.setBounds(bounds);
-        //     }
-        //   }
-        //
-        //   // 지도에 마커를 표시하는 함수입니다
-        //   function displayMarker(place) {
-        //     // 마커를 생성하고 지도에 표시합니다
-        //     const marker = new kakao.maps.Marker({
-        //       map: map,
-        //       position: new kakao.maps.LatLng(place.y, place.x),
-        //     });
-        //
-        //     // 마커에 클릭이벤트를 등록합니다
-        //     kakao.maps.event.addListener(marker, "click", function () {
-        //       // 마커를 클릭하면 장소명이 인포윈도우에 표출됩니다
-        //       infowindow.setContent(
-        //         '<div style="padding:5px;font-size:12px;height:50px;">' +
-        //         place.place_name +
-        //         "placeId: " +
-        //         place.id +
-        //         "</div>",
-        //       );
-        //       infowindow.open(map, marker);
-        //     });
-        //   }
-        //
-        //
-        // },
-        //   () => {
-        //     // 실패 시 기본 위치 (서울 시청)
-        //     const defaultCenter = new kakao.maps.LatLng(37.5665, 126.978);
-        //     const map = new kakao.maps.Map(container, {
-        //       center: defaultCenter,
-        //       level: 5,
-        //     });
-        //
-        //     // 마커를 클릭하면 장소명을 표출할 인포윈도우 입니다
-        //     const infowindow = new kakao.maps.InfoWindow({ zIndex: 1 });
-        //
-        //     // 장소 검색 객체를 생성합니다
-        //     const ps = new kakao.maps.services.Places();
-        //
-        //     // 키워드로 장소를 검색합니다
-        //     ps.keywordSearch("동현피트니스", placesSearchCB);
-        //
-        //     // 키워드 검색 완료 시 호출되는 콜백함수 입니다
-        //     function placesSearchCB(data, status, pagination) {
-        //       if (status === kakao.maps.services.Status.OK) {
-        //         // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
-        //         // LatLngBounds 객체에 좌표를 추가합니다
-        //         const bounds = new kakao.maps.LatLngBounds();
-        //
-        //         for (let i = 0; i < data.length; i++) {
-        //           displayMarker(data[i]);
-        //           bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
-        //         }
-        //
-        //         // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
-        //         map.setBounds(bounds);
-        //       }
-        //     }
-        //
-        //     // 지도에 마커를 표시하는 함수입니다
-        //     function displayMarker(place) {
-        //       // 마커를 생성하고 지도에 표시합니다
-        //       const marker = new kakao.maps.Marker({
-        //         map: map,
-        //         position: new kakao.maps.LatLng(place.y, place.x),
-        //       });
-        //
-        //       // 마커에 클릭이벤트를 등록합니다
-        //       kakao.maps.event.addListener(marker, "click", function () {
-        //         // 마커를 클릭하면 장소명이 인포윈도우에 표출됩니다
-        //         infowindow.setContent(
-        //           '<div style="padding:5px;font-size:12px;height:50px;">' +
-        //           place.place_name +
-        //           "placeId: " +
-        //           place.id +
-        //           "</div>",
-        //         );
-        //         infowindow.open(map, marker);
-        //       });
-        //     }
-
-
-          }
-
-
-          );
-
-        // const defaultCenter = new window.kakao.maps.LatLng(37.5665, 126.978);
-
-
-
-
-
-
-      });
-    };
-    document.head.appendChild(script);
+    loadKakaoMapSdk(() => {
+      if (mapRef.current) {
+        initializeMap(mapRef.current);
+      }
+    });
   }, []);
 
-  return (
-    <>
-      <div ref={mapRef} className={`absolute w-screen h-screen left-0`} />
-    </>
-  );
+  return <div ref={mapRef} className="absolute w-screen h-screen left-0" />;
 }

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -26,14 +26,15 @@ export default function PlaceModal() {
           );
           setPlaceList(data);
         } catch (error) {
+          setPlaceList(null);
           // showToastMessage({
           //   type: "error",
           //   message: "장소 목록을 불러오는 데 실패했습니다.",
           // });
-          console.error("장소 목록을 불러오는 데 실패했습니다.", error);
+          console.error("장소 목록을 불러오는 데 실패했습니다.");
         }
       })();
-    }, 800); // 800ms 동안 변화가 없을 경우에만 API 호출
+    }, 500); // 800ms 동안 변화가 없을 경우에만 API 호출
 
     return () => clearTimeout(timer); // 위치가 변경되면 이전 요청 타이머 제거
   }, [myLocation]);

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -7,7 +7,7 @@ import { useToastMessageContext } from "@/providers/ToastMessageProvider";
 
 export default function PlaceModal() {
   const placeList = useMapStore((state) => state.placeList);
-  const { setPlaceList } = useMapStore();
+  const { setPlaceList, regionName } = useMapStore();
   const { showToastMessage } = useToastMessageContext();
 
 
@@ -36,7 +36,7 @@ export default function PlaceModal() {
       {/* 헤더 */}
       <div className="px-4 pt-4">
         <span className="text-2xl font-extrabold block text-gray900">
-          서울시 &gt; 강남구
+          {regionName}
         </span>
         <div className="flex justify-end">
           <span className="text-sm text-gray-400">즐겨찾기 많은 순</span>

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -3,33 +3,40 @@ import PlaceCard from "@/components/map/PlaceCard";
 import { PlaceListResponse } from "@/types/map";
 import { fetchPlaceList } from "@/lib/api/map";
 import { useMapStore } from "@/stores/mapStore";
-import { useToastMessageContext } from "@/providers/ToastMessageProvider";
+import FallbackMessage from "@/components/common/Fallback/FallbackMessage";
 
 export default function PlaceModal() {
-  const placeList = useMapStore((state) => state.placeList);
+  const { placeList, myLocation } = useMapStore((state) => state);
   const { setPlaceList, regionName } = useMapStore();
-  const { showToastMessage } = useToastMessageContext();
-
 
   useEffect(() => {
-    const lat = 37.554722;
-    const lng = 126.97083;
-    const distanceKm = 5;
+    if (!myLocation?.lat || !myLocation?.lng) return;
 
-    (async () => {
-      try {
-        const data: PlaceListResponse = await fetchPlaceList(
-          lat,
-          lng,
-          distanceKm,
-        );
-        setPlaceList(data);
-      } catch (error) {
-        showToastMessage({type: "error", message: "장소 목록을 불러오는 데 실패했습니다."})
-        console.error("장소 목록을 불러오는 데 실패했습니다.", error);
-      }
-    })();
-  }, []);
+    const timer = setTimeout(() => {
+      const lat = myLocation.lat;
+      const lng = myLocation.lng;
+      const distanceKm = 5;
+
+      (async () => {
+        try {
+          const data: PlaceListResponse = await fetchPlaceList(
+            lat,
+            lng,
+            distanceKm
+          );
+          setPlaceList(data);
+        } catch (error) {
+          // showToastMessage({
+          //   type: "error",
+          //   message: "장소 목록을 불러오는 데 실패했습니다.",
+          // });
+          console.error("장소 목록을 불러오는 데 실패했습니다.", error);
+        }
+      })();
+    }, 800); // 800ms 동안 변화가 없을 경우에만 API 호출
+
+    return () => clearTimeout(timer); // 위치가 변경되면 이전 요청 타이머 제거
+  }, [myLocation]);
 
   return (
     <div className="flex flex-col absolute -bottom-4 left-0 z-10 w-96 h-96 bg-white rounded-t-2xl shadow-lg overflow-hidden">
@@ -45,16 +52,20 @@ export default function PlaceModal() {
 
       {/* 장소 카드 리스트 */}
       <ul className="flex flex-col gap-3 px-4 py-4 overflow-y-auto">
-        {placeList?.placeInfos.map((place) => (
-          <PlaceCard
-            key={place.placeId}
-            placeId={place.placeId}
-            category={place.category}
-            placeName={place.name}
-            address={place.address}
-            favoriteCount={place.favoriteCount}
-          />
-        ))}
+        {placeList ? (
+          placeList.placeInfos.map((place) => (
+            <PlaceCard
+              key={place.placeId}
+              placeId={place.placeId}
+              category={place.category}
+              placeName={place.name}
+              address={place.address}
+              favoriteCount={place.favoriteCount}
+            />
+          ))
+        ) : (
+          <FallbackMessage message="인근에 조회된 장소가 없습니다."/>
+        )}
       </ul>
     </div>
   );

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -15,7 +15,7 @@ export default function PlaceModal() {
     const timer = setTimeout(() => {
       const lat = myLocation.lat;
       const lng = myLocation.lng;
-      const distanceKm = 5;
+      const distanceKm = 3;
 
       (async () => {
         try {
@@ -27,16 +27,12 @@ export default function PlaceModal() {
           setPlaceList(data);
         } catch (error) {
           setPlaceList(null);
-          // showToastMessage({
-          //   type: "error",
-          //   message: "장소 목록을 불러오는 데 실패했습니다.",
-          // });
           console.warn("장소 목록을 불러오는 데 실패했습니다.", error);
         }
       })();
-    }, 500); // 800ms 동안 변화가 없을 경우에만 API 호출
+    }, 500);
 
-    return () => clearTimeout(timer); // 위치가 변경되면 이전 요청 타이머 제거
+    return () => clearTimeout(timer);
   }, [myLocation]);
 
   return (

--- a/src/components/map/PlaceModal.tsx
+++ b/src/components/map/PlaceModal.tsx
@@ -31,7 +31,7 @@ export default function PlaceModal() {
           //   type: "error",
           //   message: "장소 목록을 불러오는 데 실패했습니다.",
           // });
-          console.error("장소 목록을 불러오는 데 실패했습니다.");
+          console.warn("장소 목록을 불러오는 데 실패했습니다.", error);
         }
       })();
     }, 500); // 800ms 동안 변화가 없을 경우에만 API 호출

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -42,6 +42,10 @@ interface MapStore {
   // 즐겨찾기 추가 모달
   favoriteAddModal: boolean;
   setFavoriteAddModal: (favoriteAddModal: boolean) => void;
+
+  // 내 위치
+  myLocation : {lat: number, lng: number} | null;
+  setMyLocation: (myLocation : {lat: number, lng: number}) => void;
 }
 
 export const useMapStore = create<MapStore>((set) => ({
@@ -56,6 +60,8 @@ export const useMapStore = create<MapStore>((set) => ({
   favoriteAddModal: false,
   favoriteList: null,
   groupInfo: null,
+  myLocation : null,
+
 
   setPagePlaceList: () =>
     set(() => ({
@@ -99,5 +105,9 @@ export const useMapStore = create<MapStore>((set) => ({
   setGroupInfo: (groupInfo: GroupListResponse) =>
     set(() => ({
       groupInfo: groupInfo,
+    })),
+  setMyLocation: (myLocation : {lat: number, lng: number}) =>
+    set(() => ({
+      myLocation: myLocation,
     }))
 }));

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -45,7 +45,9 @@ interface MapStore {
 
   // 내 위치
   myLocation : {lat: number, lng: number} | null;
+  regionName: string | null;
   setMyLocation: (myLocation : {lat: number, lng: number}) => void;
+  setRegionName: (myRegionName : string) => void;
 }
 
 export const useMapStore = create<MapStore>((set) => ({
@@ -61,6 +63,7 @@ export const useMapStore = create<MapStore>((set) => ({
   favoriteList: null,
   groupInfo: null,
   myLocation : null,
+  regionName: null,
 
 
   setPagePlaceList: () =>
@@ -109,5 +112,9 @@ export const useMapStore = create<MapStore>((set) => ({
   setMyLocation: (myLocation : {lat: number, lng: number}) =>
     set(() => ({
       myLocation: myLocation,
-    }))
+    })),
+  setRegionName: (regionName : string) =>
+    set(() => ({
+      regionName: regionName,
+    })),
 }));

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import {
   FavoriteListResponse,
-  GroupListResponse,
+  GroupListResponse, MyLoc,
   PAGE,
   PageType,
   PlaceDetailResponse,
@@ -23,7 +23,7 @@ interface MapStore {
 
   // 장소 리스트
   placeList: PlaceListResponse | null;
-  setPlaceList: (placeList: PlaceListResponse) => void;
+  setPlaceList: (placeList: PlaceListResponse | null) => void;
 
   // 장소 상세
   placeDetail: PlaceDetailResponse | null;
@@ -44,7 +44,7 @@ interface MapStore {
   setFavoriteAddModal: (favoriteAddModal: boolean) => void;
 
   // 내 위치
-  myLocation : {lat: number, lng: number} | null;
+  myLocation : MyLoc | null;
   regionName: string | null;
   setMyLocation: (myLocation : {lat: number, lng: number}) => void;
   setRegionName: (myRegionName : string) => void;
@@ -80,7 +80,7 @@ export const useMapStore = create<MapStore>((set) => ({
       page: PAGE.USERGROUPLIST,
       otherUserId: otherUserId,
     })),
-  setPlaceList: (placeList: PlaceListResponse) =>
+  setPlaceList: (placeList: PlaceListResponse | null) =>
     set(() => ({
       placeList: placeList,
     })),
@@ -109,7 +109,7 @@ export const useMapStore = create<MapStore>((set) => ({
     set(() => ({
       groupInfo: groupInfo,
     })),
-  setMyLocation: (myLocation : {lat: number, lng: number}) =>
+  setMyLocation: (myLocation : MyLoc) =>
     set(() => ({
       myLocation: myLocation,
     })),

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -66,3 +66,15 @@ export interface FavoriteListResponse {
   address: string,
   deleted: boolean
 }
+
+export interface MyLoc {
+  lat: number,
+  lng: number
+}
+
+export type markerInfos = markerInfo[];
+
+export interface markerInfo {
+  title: string;
+  latlng: MyLoc;
+}

--- a/src/utils/mapUtil.ts
+++ b/src/utils/mapUtil.ts
@@ -1,0 +1,35 @@
+const KAKAO_MAP_API_KEY = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID!;
+
+// Kakao SDK 로드 함수
+export const loadKakaoMapSdk = (callback: () => void) => {
+  const script = document.createElement("script");
+  script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_MAP_API_KEY}&autoload=false&libraries=services`;
+  script.async = true;
+  script.onload = () => {
+    window.kakao.maps.load(callback);
+  };
+  document.head.appendChild(script);
+};
+
+// 지도 초기화 함수
+export const initializeMap = (container: HTMLDivElement) => {
+  navigator.geolocation.getCurrentPosition(
+    (position) => {
+      const lat = position.coords.latitude;
+      const lng = position.coords.longitude;
+      const center = new window.kakao.maps.LatLng(lat, lng);
+
+      new window.kakao.maps.Map(container, {
+        center,
+        level: 3,
+      });
+    },
+    () => {
+      const fallback = new window.kakao.maps.LatLng(37.5665, 126.978); // 서울 시청
+      new window.kakao.maps.Map(container, {
+        center: fallback,
+        level: 5,
+      });
+    },
+  );
+};

--- a/src/utils/mapUtil.ts
+++ b/src/utils/mapUtil.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { markerInfo, PlaceListResponse } from "@/types/map";
 
 const KAKAO_MAP_API_KEY = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID!;

--- a/src/utils/mapUtil.ts
+++ b/src/utils/mapUtil.ts
@@ -1,26 +1,4 @@
-// Kakao 객체를 전역 선언합니다.
-declare global {
-  interface Window {
-    kakao: {
-      maps: {
-        LatLng: new (lat: number, lng: number) => void;
-        Map: new (
-          container: HTMLElement,
-          options: { center: void; level: number },
-        ) => void;
-        load: (callback: () => void) => void;
-      };
-    };
-  }
-}
-
 import { markerInfo, PlaceListResponse } from "@/types/map";
-
-// declare global {
-//   interface Window {
-//     kakao: any; // kakao.maps.* 전부 포괄
-//   }
-// }
 
 const KAKAO_MAP_API_KEY = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID!;
 
@@ -64,49 +42,6 @@ export const initializeMap = (
       callback(map);
     },
   );
-};
-
-// 마커 표시 함수 (재사용 가능)
-export const addMarkers = (map: any) => {
-  const kakao = window.kakao;
-
-  // 마커 목록
-  const positions = [
-    {
-      title: "카카오",
-      latlng: new kakao.maps.LatLng(33.450705, 126.570677),
-    },
-    {
-      title: "생태연못",
-      latlng: new kakao.maps.LatLng(33.450936, 126.569477),
-    },
-    {
-      title: "텃밭",
-      latlng: new kakao.maps.LatLng(33.450879, 126.56994),
-    },
-    {
-      title: "근린공원",
-      latlng: new kakao.maps.LatLng(33.451393, 126.570738),
-    },
-    {
-      title: "dd",
-      latlng: new kakao.maps.LatLng(37.55123, 127.1234455),
-    },
-  ];
-
-  const imageSrc =
-    "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png";
-  const imageSize = new kakao.maps.Size(24, 35);
-  const markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize);
-
-  positions.forEach((pos) => {
-    new kakao.maps.Marker({
-      map,
-      position: pos.latlng,
-      title: pos.title,
-      image: markerImage,
-    });
-  });
 };
 
 // 내 위치를 추적해서 전역상태변수에 저장
@@ -176,7 +111,6 @@ export function updateCenterAddress(
   });
 }
 
-
 export function placeToMarker(places: PlaceListResponse | null, map: any) {
   if (!places || !places.placeInfos || places.placeInfos.length === 0) {
     console.warn("placeToMarker: 유효한 장소 목록이 없습니다.");
@@ -189,7 +123,8 @@ export function placeToMarker(places: PlaceListResponse | null, map: any) {
     latlng: { lat: place.lat, lng: place.lng },
   }));
 
-  const imageSrc = "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png";
+  const imageSrc =
+    "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png";
   const imageSize = new window.kakao.maps.Size(24, 35);
   const markerImage = new window.kakao.maps.MarkerImage(imageSrc, imageSize);
 

--- a/src/utils/mapUtil.ts
+++ b/src/utils/mapUtil.ts
@@ -14,6 +14,8 @@
 //   }
 // }
 
+import { markerInfo, PlaceListResponse } from "@/types/map";
+
 declare global {
   interface Window {
     kakao: any; // kakao.maps.* 전부 포괄
@@ -172,4 +174,41 @@ export function updateCenterAddress(
       },
     );
   });
+}
+
+
+export function placeToMarker(places: PlaceListResponse, map: any) {
+  const positions: markerInfo[] = [];
+
+  places.placeInfos.map((place) => {
+    const position: markerInfo = {
+      title: place.name,
+      latlng: { lat: place.lat, lng: place.lng },
+    };
+    positions.push(position);
+  });
+
+  console.log("positions", positions);
+
+  // 마커 이미지의 이미지 주소입니다
+  const imageSrc =
+    "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png";
+
+  for (let i = 0; i < positions.length; i++) {
+    // 마커 이미지의 이미지 크기 입니다
+    const imageSize = new window.kakao.maps.Size(24, 35);
+
+    // 마커 이미지를 생성합니다
+    const markerImage = new window.kakao.maps.MarkerImage(imageSrc, imageSize);
+
+    // 마커를 생성합니다
+    const marker = new window.kakao.maps.Marker({
+      map: map, // 마커를 표시할 지도
+      position: positions[i].latlng, // 마커를 표시할 위치
+      title: positions[i].title, // 마커의 타이틀, 마커에 마우스를 올리면 타이틀이 표시됩니다
+      image: markerImage, // 마커 이미지
+    });
+
+    marker.setMap(map);
+  }
 }

--- a/src/utils/mapUtil.ts
+++ b/src/utils/mapUtil.ts
@@ -177,38 +177,32 @@ export function updateCenterAddress(
 }
 
 
-export function placeToMarker(places: PlaceListResponse, map: any) {
-  const positions: markerInfo[] = [];
+export function placeToMarker(places: PlaceListResponse | null, map: any) {
+  if (!places || !places.placeInfos || places.placeInfos.length === 0) {
+    console.warn("placeToMarker: 유효한 장소 목록이 없습니다.");
 
-  places.placeInfos.map((place) => {
-    const position: markerInfo = {
-      title: place.name,
-      latlng: { lat: place.lat, lng: place.lng },
-    };
-    positions.push(position);
-  });
+    return;
+  }
+
+  const positions: markerInfo[] = places.placeInfos.map((place) => ({
+    title: place.name,
+    latlng: { lat: place.lat, lng: place.lng },
+  }));
 
   console.log("positions", positions);
 
-  // 마커 이미지의 이미지 주소입니다
-  const imageSrc =
-    "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png";
+  const imageSrc = "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png";
+  const imageSize = new window.kakao.maps.Size(24, 35);
+  const markerImage = new window.kakao.maps.MarkerImage(imageSrc, imageSize);
 
-  for (let i = 0; i < positions.length; i++) {
-    // 마커 이미지의 이미지 크기 입니다
-    const imageSize = new window.kakao.maps.Size(24, 35);
-
-    // 마커 이미지를 생성합니다
-    const markerImage = new window.kakao.maps.MarkerImage(imageSrc, imageSize);
-
-    // 마커를 생성합니다
+  positions.forEach((pos) => {
     const marker = new window.kakao.maps.Marker({
-      map: map, // 마커를 표시할 지도
-      position: positions[i].latlng, // 마커를 표시할 위치
-      title: positions[i].title, // 마커의 타이틀, 마커에 마우스를 올리면 타이틀이 표시됩니다
-      image: markerImage, // 마커 이미지
+      map: map,
+      position: new window.kakao.maps.LatLng(pos.latlng.lat, pos.latlng.lng),
+      title: pos.title,
+      image: markerImage,
     });
 
     marker.setMap(map);
-  }
+  });
 }

--- a/src/utils/mapUtil.ts
+++ b/src/utils/mapUtil.ts
@@ -138,7 +138,6 @@ export const setupGeocoder = () => {
 export function updateCenterAddress(
   map: any,
   setRegionName: (region: string) => void,
-  callback: (address: string) => void,
 ) {
   setupGeocoder();
 
@@ -152,7 +151,6 @@ export function updateCenterAddress(
         const region = result.find((r: any) => r.region_type === "H");
         if (region) {
           setRegionName(region.address_name);
-          callback(region.address_name);
         }
       }
     },
@@ -169,39 +167,9 @@ export function updateCenterAddress(
           const region = result.find((r: any) => r.region_type === "H");
           if (region) {
             setRegionName(region.address_name); // 행정동 이름을 전역 상태에 저장
-            callback(region.address_name);
           }
         }
       },
     );
-  });
-}
-
-// 클릭한 위치에 마커와 주소 출력
-export function enableClickToShowAddress(map: any) {
-  setupGeocoder();
-
-  const marker = new window.kakao.maps.Marker();
-  const infowindow = new window.kakao.maps.InfoWindow({ zIndex: 1 });
-
-  window.kakao.maps.event.addListener(map, "click", function (mouseEvent: any) {
-    const coords = mouseEvent.latLng;
-    geocoder.coord2Address(coords.getLng(), coords.getLat(), function (result: any, status: any) {
-      if (status === window.kakao.maps.services.Status.OK) {
-        const roadAddr = result[0].road_address?.address_name;
-        const jibunAddr = result[0].address?.address_name;
-
-        const content = `<div class="bAddr">
-          <span class="title">법정동 주소정보</span>
-          ${roadAddr ? `<div>도로명주소 : ${roadAddr}</div>` : ""}
-          <div>지번 주소 : ${jibunAddr}</div>
-        </div>`;
-
-        marker.setPosition(coords);
-        marker.setMap(map);
-        infowindow.setContent(content);
-        infowindow.open(map, marker);
-      }
-    });
   });
 }

--- a/src/utils/mapUtil.ts
+++ b/src/utils/mapUtil.ts
@@ -1,3 +1,24 @@
+// Kakao 객체를 전역 선언합니다.
+// declare global {
+//   interface Window {
+//     kakao: {
+//       maps: {
+//         LatLng: new (lat: number, lng: number) => void;
+//         Map: new (
+//           container: HTMLElement,
+//           options: { center: void; level: number },
+//         ) => void;
+//         load: (callback: () => void) => void;
+//       };
+//     };
+//   }
+// }
+declare global {
+  interface Window {
+    kakao: any; // kakao.maps.* 전부 포괄
+  }
+}
+
 const KAKAO_MAP_API_KEY = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID!;
 
 // Kakao SDK 로드 함수
@@ -11,25 +32,78 @@ export const loadKakaoMapSdk = (callback: () => void) => {
   document.head.appendChild(script);
 };
 
-// 지도 초기화 함수
-export const initializeMap = (container: HTMLDivElement) => {
+// 지도 초기화
+export const initializeMap = (
+  container: HTMLDivElement,
+  callback: (map: any) => void
+) => {
   navigator.geolocation.getCurrentPosition(
     (position) => {
-      const lat = position.coords.latitude;
-      const lng = position.coords.longitude;
-      const center = new window.kakao.maps.LatLng(lat, lng);
+      const center = new window.kakao.maps.LatLng(
+        position.coords.latitude,
+        position.coords.longitude
+      );
 
-      new window.kakao.maps.Map(container, {
+      const map = new window.kakao.maps.Map(container, {
         center,
         level: 3,
       });
+
+      callback(map);
     },
     () => {
       const fallback = new window.kakao.maps.LatLng(37.5665, 126.978); // 서울 시청
-      new window.kakao.maps.Map(container, {
+      const map = new window.kakao.maps.Map(container, {
         center: fallback,
         level: 5,
       });
-    },
+
+      callback(map);
+    }
   );
+};
+
+
+
+// 마커 표시 함수 (재사용 가능)
+export const addMarkers = (map: any) => {
+  const kakao = window.kakao;
+
+  // 마커 목록
+  const positions = [
+    {
+      title: "카카오",
+      latlng: new kakao.maps.LatLng(33.450705, 126.570677),
+    },
+    {
+      title: "생태연못",
+      latlng: new kakao.maps.LatLng(33.450936, 126.569477),
+    },
+    {
+      title: "텃밭",
+      latlng: new kakao.maps.LatLng(33.450879, 126.56994),
+    },
+    {
+      title: "근린공원",
+      latlng: new kakao.maps.LatLng(33.451393, 126.570738),
+    },
+    {
+      title: "dd",
+      latlng: new kakao.maps.LatLng(37.55123, 127.1234455)
+    }
+  ];
+
+  const imageSrc =
+    "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png";
+  const imageSize = new kakao.maps.Size(24, 35);
+  const markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize);
+
+  positions.forEach((pos) => {
+    new kakao.maps.Marker({
+      map,
+      position: pos.latlng,
+      title: pos.title,
+      image: markerImage,
+    });
+  });
 };

--- a/src/utils/mapUtil.ts
+++ b/src/utils/mapUtil.ts
@@ -13,6 +13,8 @@
 //     };
 //   }
 // }
+import { useMapStore } from "@/stores/mapStore";
+
 declare global {
   interface Window {
     kakao: any; // kakao.maps.* 전부 포괄
@@ -35,13 +37,13 @@ export const loadKakaoMapSdk = (callback: () => void) => {
 // 지도 초기화
 export const initializeMap = (
   container: HTMLDivElement,
-  callback: (map: any) => void
+  callback: (map: any) => void,
 ) => {
   navigator.geolocation.getCurrentPosition(
     (position) => {
       const center = new window.kakao.maps.LatLng(
         position.coords.latitude,
-        position.coords.longitude
+        position.coords.longitude,
       );
 
       const map = new window.kakao.maps.Map(container, {
@@ -59,11 +61,9 @@ export const initializeMap = (
       });
 
       callback(map);
-    }
+    },
   );
 };
-
-
 
 // 마커 표시 함수 (재사용 가능)
 export const addMarkers = (map: any) => {
@@ -89,8 +89,8 @@ export const addMarkers = (map: any) => {
     },
     {
       title: "dd",
-      latlng: new kakao.maps.LatLng(37.55123, 127.1234455)
-    }
+      latlng: new kakao.maps.LatLng(37.55123, 127.1234455),
+    },
   ];
 
   const imageSrc =
@@ -107,3 +107,19 @@ export const addMarkers = (map: any) => {
     });
   });
 };
+
+// 내 위치를 추적해서 전역상태변수에 저장
+export function moveMyLocation(map: any, setMyLocation: (loc: { lat: number; lng: number }) => void) {
+  window.kakao.maps.event.addListener(map, "center_changed", function () {
+    // 지도의  레벨을 얻어옵니다
+    // const level = map.getLevel();
+
+    // 지도의 중심좌표를 얻어옵니다
+    const latlng = map.getCenter();
+
+    const lat = latlng.getLat();
+    const lng = latlng.getLng();
+
+    setMyLocation({ lat, lng });
+  });
+}

--- a/src/utils/mapUtil.ts
+++ b/src/utils/mapUtil.ts
@@ -1,26 +1,26 @@
 // Kakao 객체를 전역 선언합니다.
-// declare global {
-//   interface Window {
-//     kakao: {
-//       maps: {
-//         LatLng: new (lat: number, lng: number) => void;
-//         Map: new (
-//           container: HTMLElement,
-//           options: { center: void; level: number },
-//         ) => void;
-//         load: (callback: () => void) => void;
-//       };
-//     };
-//   }
-// }
+declare global {
+  interface Window {
+    kakao: {
+      maps: {
+        LatLng: new (lat: number, lng: number) => void;
+        Map: new (
+          container: HTMLElement,
+          options: { center: void; level: number },
+        ) => void;
+        load: (callback: () => void) => void;
+      };
+    };
+  }
+}
 
 import { markerInfo, PlaceListResponse } from "@/types/map";
 
-declare global {
-  interface Window {
-    kakao: any; // kakao.maps.* 전부 포괄
-  }
-}
+// declare global {
+//   interface Window {
+//     kakao: any; // kakao.maps.* 전부 포괄
+//   }
+// }
 
 const KAKAO_MAP_API_KEY = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID!;
 
@@ -188,8 +188,6 @@ export function placeToMarker(places: PlaceListResponse | null, map: any) {
     title: place.name,
     latlng: { lat: place.lat, lng: place.lng },
   }));
-
-  console.log("positions", positions);
 
   const imageSrc = "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png";
   const imageSize = new window.kakao.maps.Size(24, 35);

--- a/src/utils/mapUtil.ts
+++ b/src/utils/mapUtil.ts
@@ -137,10 +137,28 @@ export const setupGeocoder = () => {
 // 중심 좌표 주소정보를 가져와 콜백 실행
 export function updateCenterAddress(
   map: any,
+  setRegionName: (region: string) => void,
   callback: (address: string) => void,
 ) {
   setupGeocoder();
 
+  // 최초 1회 즉시 실행, null값 방지
+  const center = map.getCenter();
+  geocoder.coord2RegionCode(
+    center.getLng(),
+    center.getLat(),
+    (result: any, status: any) => {
+      if (status === window.kakao.maps.services.Status.OK) {
+        const region = result.find((r: any) => r.region_type === "H");
+        if (region) {
+          setRegionName(region.address_name);
+          callback(region.address_name);
+        }
+      }
+    },
+  );
+
+  // 확대 축소 이벤트 감지
   window.kakao.maps.event.addListener(map, "idle", () => {
     const center = map.getCenter();
     geocoder.coord2RegionCode(
@@ -150,6 +168,7 @@ export function updateCenterAddress(
         if (status === window.kakao.maps.services.Status.OK) {
           const region = result.find((r: any) => r.region_type === "H");
           if (region) {
+            setRegionName(region.address_name); // 행정동 이름을 전역 상태에 저장
             callback(region.address_name);
           }
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    "types": [
+      "kakao.maps.d.ts"
+    ],
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,


### PR DESCRIPTION
## 📌 작업 개요
- 등록되어있는 장소들 마커 표시 추가, 내 위치 기반 행정동 이름 업데이트되도록 수정


## ✨ 주요 변경 사항
- 지도 중심 위치에 따라 등록되어 있는 장소들의 마커가 동적으로 추가되도록 하였습니다.
- 장소 리스트 모달의 헤더에 하드코딩 데이터에서 동적으로 행정동 이름이 반영되도록 하였습니다.
- console error 를 일부 warn으로 수정하였습니다.
- 카카오지도 관련 라이브러리로 타입 지정 문제를 해결했습니다.
- 메서드의 매개변수 관련 타입 지정 문제는 일단 파일 최상단에  /* eslint-disable */ 를 추가해서 무시했습니다.
- 인근 장소가 없을 때 공백으로 나타나던 디자인을 예외 메시지가 출력되도록 하였습니다.
- 지저분하게 kakaoMap.tsx 에 모여있던 메서드들을 mapUtil.ts에 분리했습니다.

## 🖼️ 스크린샷 (선택)

https://github.com/user-attachments/assets/e14e73ed-3337-4252-a9d3-b0a3ac664b64

- 지도 중심 기준 행정동 이름이 계속 업데이트 됩니다.
- DB에 저장되어 있는 장소가 지도의 위치가 업데이트 될 때 같이 마커로 표시됩니다.
- 조회된 장소가 없을 때 좌측 하단 장소 모달에 "인근에 조회된 장소가 없습니다" 문구를 출력합니다.



## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리


## 📂 테스트 방법
- num run build 통과



## 💬 기타 참고 사항
- close #110 
- close #77 
- 화면에 마커는 표시되지않는데 좌측하단에 장소가 뜨는 것은.. api호출할 때 조회 반경을 설정하는 값이 동적이지 않아서
일체감이 없는 것인데 일단은 이렇게 구현하고 추후에 리팩토링할 기회가 된다면 이슈에 남겨놓고 다루도록하겠습니다.
