### PR TITLE
Fix/sse notification : SSE인증 header기반으로 ref(버그 해결), 연결 유지를 위한 ping 처리, 비로그인상태에서 알림렌더링 제거, 조건부 썸네일 렌더링

### DIFF
--- a/src/components/auth/LoginForm/useLoginForm.ts
+++ b/src/components/auth/LoginForm/useLoginForm.ts
@@ -7,6 +7,7 @@ import { validateEmail, validatePassword } from "@/utils/validate";
 import { getSession, signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { ChangeEvent, FormEvent, useCallback, useState } from "react";
+import { getCookie } from "cookies-next";
 
 type FormType = "email" | "password";
 
@@ -61,7 +62,6 @@ const useLoginForm = () => {
 
   const handleLogin = async (e: FormEvent) => {
     e.preventDefault();
-
     if (!validateForm()) return;
 
     handleLoadingChange("email", true);
@@ -73,6 +73,14 @@ const useLoginForm = () => {
 
       const user = await fetchUser();
       setUser(user);
+
+      const accessToken = getCookie("access_token"); // 쿠키에서 꺼내서
+      if (accessToken && typeof accessToken === "string") {
+        useAuthStore.getState().setAccessToken(accessToken); // 전역 저장
+        console.log("accessToken 저장됨:", accessToken);
+      } else {
+        console.warn("accessToken이 쿠키에 없음");
+      }
 
       router.replace("/");
     } catch (err) {
@@ -111,6 +119,11 @@ const useLoginForm = () => {
       const user = await fetchUser();
 
       setUser(user);
+
+      // Zustand에 accessToken 저장
+      useAuthStore.getState().setAccessToken(kakaoAccessToken);
+      console.log("카카오 accessToken 저장됨:", kakaoAccessToken);
+
       router.replace("/");
     } catch (error) {
       console.error("카카오 로그인 중 에러", error);

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -114,7 +114,7 @@ const Header = ({ onMenuClick }: HeaderProps) => {
               />
             </div>
           )}
-          <NotificationButton />
+          {user?.userId && <NotificationButton />}
           {user?.userId ? (
             <Link href={`/profile/${user.userId}`}>
               <Image

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -119,8 +119,8 @@ const NotificationItem = ({ notification, onClose }: NotificationItemProps) => {
               {getRelativeTimeAgo(createdAt)}
             </span>
           </div>
-          {/* 게시물 썸네일 img (게시물 좋아요일때만) */}
-          {type === "LIKE" && (
+          {/* 게시물 썸네일 img (게시물 좋아요일 때만 + 썸네일이 존재할 때만) */}
+          {type === "LIKE" && thumbnailImage && (
             <Image
               src={getImageUrl(thumbnailImage)}
               alt="썸네일 이미지"

--- a/src/hooks/useSse.ts
+++ b/src/hooks/useSse.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useCallback } from "react";
 import { useAuthStore } from "@/stores/useAuthStore";
 import { useNotificationStore } from "@/stores/useNotificationStore";
 import type { Notification } from "@/types/notification";
@@ -9,15 +9,11 @@ import { EventSourcePolyfill } from "event-source-polyfill";
 const useSse = () => {
   const { user, accessToken } = useAuthStore();
   const { addNotification } = useNotificationStore();
-  const eventSourceRef = useRef<EventSource | null>(null);
+  const eventSourceRef = useRef<EventSourcePolyfill | null>(null);
+  const reconnectTimer = useRef<NodeJS.Timeout | null>(null);
 
-  useEffect(() => {
-    if (!user?.userId || !accessToken) return;
-
-    // 이전 연결 종료
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close();
-    }
+  const connectSse = useCallback(() => {
+    if (!accessToken) return;
 
     const eventSource = new EventSourcePolyfill(
       `${process.env.NEXT_PUBLIC_API_BASE_URL}/notifications/subscribe`,
@@ -25,12 +21,16 @@ const useSse = () => {
         headers: {
           Authorization: `Bearer ${accessToken}`,
         },
-        heartbeatTimeout: 300000, // 옵션: 5분
+        heartbeatTimeout: 30000, // 옵션: 5분
         withCredentials: false, // polyfill 사용 시 false
       },
     );
 
     eventSourceRef.current = eventSource;
+
+    eventSource.addEventListener("connect", () => {
+      console.log("✅ SSE 연결 성공");
+    });
 
     eventSource.addEventListener("notification", (event) => {
       const data: Notification = JSON.parse(event.data);
@@ -38,20 +38,40 @@ const useSse = () => {
       addNotification(data);
     });
 
-    eventSource.addEventListener("connect", () => {
-      console.log("✅ SSE 연결 성공");
-    });
-
     eventSource.onerror = (error) => {
-      console.error("❌ SSE 오류", error);
+      const message = (error as ErrorEvent)?.message ?? "";
+
+      if (message.includes("No activity within")) {
+        console.warn("⚠️ 타임아웃 감지, SSE 재연결 시도 중...");
+      } else {
+        console.error("❌ SSE 오류", error);
+      }
+
       eventSource.close();
+
+      if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
+      reconnectTimer.current = setTimeout(() => {
+        console.log("🔁 SSE 재연결 시도 중...");
+        connectSse();
+      }, 3000);
     };
+  }, [accessToken, addNotification]);
+
+  useEffect(() => {
+    if (!user?.userId || !accessToken) return;
+
+    connectSse();
 
     return () => {
       console.log("🛑 SSE 연결 종료");
-      eventSource.close();
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+      }
+      if (reconnectTimer.current) {
+        clearTimeout(reconnectTimer.current);
+      }
     };
-  }, [user?.userId, accessToken, addNotification]);
+  }, [user?.userId, accessToken, connectSse]);
 };
 
 export default useSse;

--- a/src/lib/api/notification.ts
+++ b/src/lib/api/notification.ts
@@ -1,20 +1,33 @@
 import { client } from "@/lib/fetch/client";
 import { Notification } from "@/types/notification";
+import { useAuthStore } from "@/stores/useAuthStore";
 
 export const fetchNotifications = async (): Promise<Notification[]> => {
+  const { accessToken } = useAuthStore.getState();
   return await client<Notification[]>("/notifications", {
     method: "GET",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
   });
 };
 
 export const markNotificationAsRead = async (notificationId: number) => {
+  const { accessToken } = useAuthStore.getState();
   await client(`/notifications/${notificationId}`, {
     method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
   });
 };
 
 export const markAllNotificationsAsRead = async () => {
+  const { accessToken } = useAuthStore.getState();
   return await client("/notifications/bulk", {
     method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
   });
 };

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -38,8 +38,10 @@ export interface UserInfo {
 
 interface AuthState {
   user: UserInfo | null;
+  accessToken: string | null;
   isInitialized: boolean;
   setUser: (user: UserInfo | null) => void;
+  setAccessToken: (token: string | null) => void;
   clearUser: () => void;
   setInitialized: () => void;
 }
@@ -48,15 +50,21 @@ export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       user: null,
+      accessToken: null,
       isInitialized: false,
 
       setUser: (user) => set({ user }),
-      clearUser: () => set({ user: null }),
+      clearUser: () => set({ user: null, accessToken: null }),
+      setAccessToken: (token) => set({ accessToken: token }),
       setInitialized: () => set({ isInitialized: true }),
     }),
     {
       name: "auth-storage",
-      partialize: (state) => ({ user: state.user }), // 저장할 필드만 지정
+      partialize: (state) => ({
+        // 저장할 필드만 지정
+        user: state.user,
+        accessToken: state.accessToken,
+      }),
     },
   ),
 );

--- a/src/types/event-source-polyfill.d.ts
+++ b/src/types/event-source-polyfill.d.ts
@@ -1,0 +1,14 @@
+declare module "event-source-polyfill" {
+  interface EventSourcePolyfillInit extends EventSourceInit {
+    headers?: Record<string, string>;
+    withCredentials?: boolean;
+    heartbeatTimeout?: number;
+  }
+
+  export class EventSourcePolyfill extends EventSource {
+    constructor(
+      url: string | URL,
+      eventSourceInitDict?: EventSourcePolyfillInit,
+    );
+  }
+}


### PR DESCRIPTION
## 📌 작업 개요
- SSE인증 header기반으로 ref(버그 해결), 연결 유지를 위한 ping 처리 등
- 비로그인상태에서 알림렌더링 제거, 조건부 썸네일 렌더링


## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
### 🚀 SSE
- 토큰 전역변수로 관리 추가
  - 로그인 성공 시 accessToken을 Zustand 전역 상태로 저장 (쿠키에서 꺼냄)
  - 이후 모든 인증 요청에서 해당 전역 토큰 참조
     - SSE는 기본적으로 크로스도메인 환경에서 쿠키를 전송하지 않기 때문에, 인증 정보를 전역 상태에서 꺼내는 방식으로 변경함
  
- SSE 쿠키 인증 → 헤더 인증 (event-source-polyfill 라이브러리)
  - 기존 쿠키 인증에서 헤더(Authorization : Bearer) 방식으로 전환
  - 기본 EventSource는 커스텀 헤더를 설정할 수 없기 때문에, 헤더 설정이 가능한 event-source-polyfill 사용

- SSE heartbeatTimeout 타임아웃 설정과 ping 받기 처리
  - eventSource는 45초 이내에 새로운 이벤트 전송이 없으면, 연결을 끊고 자동 재연결이 됨 (현재경우 넉넉히 65초로 세팅해둠)
  - 자동 재연결 시, 자동  header 인증은 불가능한 문제 발발 (자동 재연결 시 header가 다시 붙지 않음)
  - 따라서 서버에서 30초마다 서버 연결 유지용 ping 전송하게 처리해둠
  - 클라이언트에서는 heartbeatTimeout: 65초로 설정하여 연결 유지

- SSE 이벤트 미수신 시 자동 재연결되도록 구성
  - ping이 날아오지 않을 때 (서버가 꺼지거나 문제가 생겼을 때) SSE는 무한 재연결 시도 루프를 타게 됨
  - 이런 서버 비정상 상황에서, 재연결 시도 간격을 지수 백오프 방식으로 점점 늘려가도록 설정
  - 5회 재연결 시도까지 설정, 그래도 연결되지 않으면 연결종료 처리

### 🚀 그 외
- 로그인하지 않은 상태에서는 알림 버튼 렌더링 하지 않음
  - 메인페이지 진입 시 로그인하지 않은 경우 SSE 연결시도 방지
  - 로그아웃할 경우 버튼 렌더링 사라지고, SSE 연결 자동 종료

- 게시물 좋아요 알림에서 썸네일 null일 때 이미지 제거 처리
  - @mini0212 님 피드백
  
<br />
<br />
<br />

## 🖼️ 스크린샷 (선택)
> 크로스도메인 환경(ec2 <-> local3000)에서도 잘 작동함
> ![잘댐](https://github.com/user-attachments/assets/78a331a4-6dea-4696-b9eb-8ac94d62e09b)
> ![image](https://github.com/user-attachments/assets/2b68c66d-10bc-49a9-90cf-b1afa2db4df3)

<br />
<br />

> sse 연결 후 30초마다 잘 수신되는 ping
> <img src="https://github.com/user-attachments/assets/570ab210-b731-4004-9989-c057dbdaed1e" width="400">

<br />
<br />

> 서버 중지 시켰을 때 로그 & 설명
> ![image](https://github.com/user-attachments/assets/53b8e759-5d40-4b86-8972-c7b4658dd3d7)

<br />
<br />

> 로그아웃 시 알림버튼 렌더링 없어지고, sse 연결 종료
> ![로그아웃](https://github.com/user-attachments/assets/edf557ec-2c73-4afc-9e16-b8ac055e3815)

<br />
<br />

> 기존 알림 모달 게시글 썸네일null 렌더링 ->  null 일때 렌더링하지 않음
> <img src="https://github.com/user-attachments/assets/b0534207-898d-47e6-ae6a-3ae910ad7771" width="200">
> <img src="https://github.com/user-attachments/assets/c86b3887-2d65-4f65-8dc8-ffc2344373b8" width="200">

<br />
<br />


## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [ ] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->
- 두 유저간의 이벤트 확인을 위해 크롬 & 사파리에서 각각 Local3000 켜고 테스트
- 크로스 도메인 환경 ec2 <-> local3000 테스트 완료
- 로컬 환경 local8080 <-> local3000 테스트 완료


## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
