### PR TITLE
Ref/notification : 게시물/댓글 삭제, 유저 없을 때 알림 아이템 클릭시 토스트메시지

### DIFF
--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -66,9 +66,9 @@ const NotificationItem = ({ notification, onClose }: NotificationItemProps) => {
         showToastMessage({
           type: "error",
           message:
-            type === "COMMENT"
-              ? "삭제 처리된 댓글입니다."
-              : "삭제 처리된 게시글입니다.",
+            type === "FOLLOW"
+              ? "존재하지 않는 유저입니다."
+              : "존재하지 않는 게시글입니다.",
         });
       }
     }

--- a/src/components/notification/NotificationItem.tsx
+++ b/src/components/notification/NotificationItem.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import { getProfileImageUrl, getImageUrl } from "@/utils/image";
 import { markNotificationAsRead } from "@/lib/api/notification";
 import { useNotificationStore } from "@/stores/useNotificationStore";
+import { useToastMessageContext } from "@/providers/ToastMessageProvider";
 
 export type MainCategory = keyof typeof CATEGORY_MAP;
 
@@ -20,6 +21,7 @@ type NotificationItemProps = {
 const NotificationItem = ({ notification, onClose }: NotificationItemProps) => {
   const router = useRouter();
   const { markAsRead } = useNotificationStore();
+  const { showToastMessage } = useToastMessageContext();
 
   const {
     id,
@@ -53,8 +55,22 @@ const NotificationItem = ({ notification, onClose }: NotificationItemProps) => {
     }
 
     if (href) {
-      router.push(href);
-      onClose();
+      try {
+        const res = await fetch(href, { method: "HEAD" });
+
+        if (!res.ok) throw new Error("not found");
+
+        router.push(href);
+        onClose();
+      } catch {
+        showToastMessage({
+          type: "error",
+          message:
+            type === "COMMENT"
+              ? "삭제 처리된 댓글입니다."
+              : "삭제 처리된 게시글입니다.",
+        });
+      }
     }
   };
 


### PR DESCRIPTION
## 📌 작업 개요
- 게시물/댓글 삭제, 유저 없을 때 알림 아이템 클릭시 토스트메시지

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 대상이 not found인 알림 아이템 클릭시 토스트메시지
- 존재하지 않는 페이지로 이동하지 않도록 처리
 <br />

- 게시물 좋아요 알림 + 알림 생성 이후 해당 게시글 삭제
  - -> 존재하지 않는 게시글입니다
- 게시물 댓글 + 알림 생성 이후 해당 게시글 삭제
  - -> 존재하지 않는 게시글입니다
- 팔로우 알림 + 알림 생성 이후 해당 유저 탈퇴 (프로필페이지 없음)
  - -> 존재하지 않는 유저입니다


## 🖼️ 스크린샷 (선택)
> 게시글 삭제 전 => 아이템 클릭시 정상 이동
![게시글 삭제 전](https://github.com/user-attachments/assets/c73eab55-bf23-4f2a-a484-8ce78cbb2479)

> 게시글 삭제 후 => 아이템 클릭시 토스트 메시지 & 이동안함
![삭제된](https://github.com/user-attachments/assets/4c2b0243-c7bb-4c70-854b-cd0c474fd632)
- 삭제된 게시글의 좋아요 알림
![삭제된댓글](https://github.com/user-attachments/assets/94e58078-cde5-418a-9c14-931155741c29)
- 삭제된 게시글의 댓글 알림 
 

## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [ ] 변수명, 함수명 명확하게 작성
- [ ] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->
- local3000 <-> ec2
- 알림 생성 액션 후 게시글 삭제 & 탈퇴
- + 현재 탈퇴한 유저에 대해서는 프로필페이지가 살아있어서, notfound 처리되신 후 토스트 뜰듯합니다 


## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
