### PR TITLE
fix/kakao-sse : 카카오로그인 시 sse 401 해결

### DIFF
--- a/src/components/auth/LoginForm/useLoginForm.ts
+++ b/src/components/auth/LoginForm/useLoginForm.ts
@@ -119,8 +119,12 @@ const useLoginForm = () => {
 
       setUser(user);
 
-      // Zustand에 accessToken 저장
-      useAuthStore.getState().setAccessToken(kakaoAccessToken);
+      const accessToken = getCookie("access_token"); // 쿠키에서 꺼내서
+      if (accessToken && typeof accessToken === "string") {
+        useAuthStore.getState().setAccessToken(accessToken); // 전역 저장
+      } else {
+        console.warn("accessToken이 쿠키에 없음");
+      }
 
       router.replace("/");
     } catch (error) {


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
- 카카오로그인 시 sse 401 해결

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 카카오 로그인 시 토큰 전역저장에 kakaoAccessToken을 넣어서 했었습니다.. 수정해야지 해놓고 까먹었네요 죄삼다🫠
- `setUser(user);` 이후 쿠키에서 꺼내서 전역저장하는 것으로 수정


## 🖼️ 스크린샷 (선택)


## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [ ] 변수명, 함수명 명확하게 작성
- [ ] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->
- local에서 카카오 로그인 자체가 405라서.. 머지 후 빠른 확인 하겠습니다 (높은 확률로 잘 작동 될 것이에요)

## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
