### PR TITLE
Bug/prevdata-load map페이지 컴포넌트에 이전 데이터 남아있다가 전환되는 문제 수정

### DIFF
--- a/src/components/map/GroupsFavoriteList.tsx
+++ b/src/components/map/GroupsFavoriteList.tsx
@@ -8,11 +8,18 @@ import Image from "next/image";
 import { getProfileImageUrl } from "@/utils/image";
 import { useMapPageStore } from "@/stores/map/useMapPageStore";
 import { useMapGroupStore } from "@/stores/map/useMapGroupStore";
+import { useMapFavoriteStore } from "@/stores/map/useMapFavoriteStore";
 
 export function GroupsFavoriteList() {
   const { groupInfo } = useMapGroupStore();
   const { page, otherUserId, setPageGroupList } = useMapPageStore();
+  const { setFavoriteList } = useMapFavoriteStore();
   const { data: profile } = useProfile(otherUserId);
+
+  function onClickBackBtn() {
+    setPageGroupList(otherUserId!);
+    setFavoriteList([]);
+  }
 
   if (page === PAGE.FAVORITELIST)
     return (
@@ -22,7 +29,7 @@ export function GroupsFavoriteList() {
         <div className="flex items-center justify-between px-4 py-2 border-b">
           {/* 뒤로 가기*/}
           <button
-            onClick={() => setPageGroupList(otherUserId!)}
+            onClick={onClickBackBtn}
             className="p-1 rounded-full hover:bg-gray-100"
           >
             <ArrowLeft size={20} className="text-gray-700" />

--- a/src/components/map/GroupsFavoriteList.tsx
+++ b/src/components/map/GroupsFavoriteList.tsx
@@ -16,9 +16,10 @@ export function GroupsFavoriteList() {
   const { setFavoriteList } = useMapFavoriteStore();
   const { data: profile } = useProfile(otherUserId);
 
+  // 이전 버튼 클릭 시 이전 데이터 초기화 및 페이지 전환
   function onClickBackBtn() {
     setPageGroupList(otherUserId!);
-    setFavoriteList([]);
+    setFavoriteList([]); // 데이터 초기화
   }
 
   if (page === PAGE.FAVORITELIST)

--- a/src/components/map/PlaceUserMemosHeader.tsx
+++ b/src/components/map/PlaceUserMemosHeader.tsx
@@ -4,6 +4,7 @@ import { PlaceDetailResponse } from "@/types/map";
 import { fetchFavoriteStatus } from "@/lib/api/map";
 import { useToastMessageContext } from "@/providers/ToastMessageProvider";
 import { useMapPageStore } from "@/stores/map/useMapPageStore";
+import { useMapPlaceStore } from "@/stores/map/useMapPlaceStore";
 
 interface PlaceUserMemosHeaderProps {
   placeDetail: PlaceDetailResponse;
@@ -13,9 +14,15 @@ export default function PlaceUserMemosHeader({
   placeDetail,
 }: PlaceUserMemosHeaderProps) {
   const { placeId, setPagePlaceList } = useMapPageStore();
+  const { setPlaceDetail } = useMapPlaceStore();
   const { showToastMessage } = useToastMessageContext();
 
   const [favorite, setFavorite] = useState(false);
+
+  function onClickBackBtn() {
+    setPagePlaceList();
+    setPlaceDetail(null);
+  }
 
   useEffect(() => {
     if (placeId !== null) {
@@ -40,7 +47,7 @@ export default function PlaceUserMemosHeader({
   return (
     <div className="relative w-full px-4 py-4">
       <div className="flex flex-col items-center justify-center">
-        <button className="absolute left-4 top-4" onClick={setPagePlaceList}>
+        <button className="absolute left-4 top-4" onClick={onClickBackBtn}>
           <ArrowLeftIcon />
         </button>
 

--- a/src/components/map/PlaceUserMemosHeader.tsx
+++ b/src/components/map/PlaceUserMemosHeader.tsx
@@ -19,9 +19,10 @@ export default function PlaceUserMemosHeader({
 
   const [favorite, setFavorite] = useState(false);
 
+  // 이전 버튼 클릭 시 이전 데이터 초기화
   function onClickBackBtn() {
     setPagePlaceList();
-    setPlaceDetail(null);
+    setPlaceDetail(null); // 데이터 초기화
   }
 
   useEffect(() => {

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -7,10 +7,17 @@ import Link from "next/link";
 import { getProfileImageUrl } from "@/utils/image";
 import Image from "next/image";
 import { useMapPageStore } from "@/stores/map/useMapPageStore";
+import { useMapGroupStore } from "@/stores/map/useMapGroupStore";
 
 export function UserGroupList() {
   const { placeId, page, otherUserId, setPagePlaceDetail } = useMapPageStore();
+  const { setGroupList } = useMapGroupStore();
   const { data: profile } = useProfile(otherUserId);
+
+  function onClickBackBtn() {
+    setPagePlaceDetail(placeId!);
+    setGroupList([]); // 이전 버튼 클릭 시 저장되어있던 데이터 초기화
+  }
 
   if (page === PAGE.USERGROUPLIST)
     return (
@@ -20,7 +27,7 @@ export function UserGroupList() {
         <div className="flex items-center justify-between px-4 py-2 border-b">
           {/* 뒤로 가기*/}
           <button
-            onClick={() => setPagePlaceDetail(placeId!)}
+            onClick={onClickBackBtn}
             className="p-1 rounded-full hover:bg-gray-100"
           >
             <ArrowLeft size={20} className="text-gray-700" />

--- a/src/components/map/UserGroupList.tsx
+++ b/src/components/map/UserGroupList.tsx
@@ -14,9 +14,10 @@ export function UserGroupList() {
   const { setGroupList } = useMapGroupStore();
   const { data: profile } = useProfile(otherUserId);
 
+  // 이전 버튼 클릭시 이전 데이터 초기화
   function onClickBackBtn() {
     setPagePlaceDetail(placeId!);
-    setGroupList([]); // 이전 버튼 클릭 시 저장되어있던 데이터 초기화
+    setGroupList([]); // 데이터 초기화
   }
 
   if (page === PAGE.USERGROUPLIST)

--- a/src/stores/map/useMapFavoriteStore.ts
+++ b/src/stores/map/useMapFavoriteStore.ts
@@ -4,7 +4,7 @@ import { FavoriteListResponse } from "@/types/map";
 interface useMapFavoriteStore {
   // 즐겨찾기 리스트
   favoriteList: FavoriteListResponse[] | [];
-  setFavoriteList: (favoriteList: FavoriteListResponse[]) => void;
+  setFavoriteList: (favoriteList: FavoriteListResponse[] | []) => void;
 
   // 즐겨찾기 추가 모달
   favoriteAddModal: boolean;
@@ -20,7 +20,7 @@ export const useMapFavoriteStore = create<useMapFavoriteStore>((set) => ({
     set(() => ({
       favoriteAddModal: !favoriteAddModal,
     })),
-  setFavoriteList: (favoriteList: FavoriteListResponse[]) =>
+  setFavoriteList: (favoriteList: FavoriteListResponse[] | []) =>
     set(() => ({
       favoriteList: favoriteList,
     })),

--- a/src/stores/map/useMapGroupStore.ts
+++ b/src/stores/map/useMapGroupStore.ts
@@ -4,7 +4,7 @@ import { GroupListResponse } from "@/types/map";
 interface useMapGroupStore {
   // 유저 그룹 리스트
   groupList: GroupListResponse[] | [];
-  setGroupList: (groupList: GroupListResponse[]) => void;
+  setGroupList: (groupList: GroupListResponse[] | []) => void;
 
   groupInfo: GroupListResponse | null;
   setGroupInfo: (groupInfo: GroupListResponse) => void;
@@ -15,7 +15,7 @@ export const useMapGroupStore = create<useMapGroupStore>((set) => ({
   groupList: [],
   groupInfo: null,
 
-  setGroupList: (groupList: GroupListResponse[]) =>
+  setGroupList: (groupList: GroupListResponse[] | []) =>
     set(() => ({
       groupList: groupList,
     })),

--- a/src/stores/map/useMapPlaceStore.ts
+++ b/src/stores/map/useMapPlaceStore.ts
@@ -8,7 +8,7 @@ import {
 interface useMapPlaceStore {
   // 장소 리스트
   placeList: PlaceListResponse | null;
-  setPlaceList: (placeList: PlaceListResponse) => void;
+  setPlaceList: (placeList: PlaceListResponse | null) => void;
 
   // 장소 상세
   placeDetail: PlaceDetailResponse | null;
@@ -25,7 +25,7 @@ export const useMapPlaceStore = create<useMapPlaceStore>((set) => ({
   placeDetail: null,
   selectPlaceDetail: null,
 
-  setPlaceList: (placeList: PlaceListResponse) =>
+  setPlaceList: (placeList: PlaceListResponse | null) =>
     set(() => ({
       placeList: placeList,
     })),

--- a/src/stores/map/useMapPlaceStore.ts
+++ b/src/stores/map/useMapPlaceStore.ts
@@ -8,11 +8,11 @@ import {
 interface useMapPlaceStore {
   // 장소 리스트
   placeList: PlaceListResponse | null;
-  setPlaceList: (placeList: PlaceListResponse | null) => void;
+  setPlaceList: (placeList: PlaceListResponse) => void;
 
   // 장소 상세
   placeDetail: PlaceDetailResponse | null;
-  setPlaceDetail: (placeDetail: PlaceDetailResponse) => void;
+  setPlaceDetail: (placeDetail: PlaceDetailResponse | null) => void;
 
   // 선택한 장소의 상세 정보
   selectPlaceDetail: KakaoMapResponse | null;
@@ -25,11 +25,11 @@ export const useMapPlaceStore = create<useMapPlaceStore>((set) => ({
   placeDetail: null,
   selectPlaceDetail: null,
 
-  setPlaceList: (placeList: PlaceListResponse | null) =>
+  setPlaceList: (placeList: PlaceListResponse) =>
     set(() => ({
       placeList: placeList,
     })),
-  setPlaceDetail: (placeDetail: PlaceDetailResponse) =>
+  setPlaceDetail: (placeDetail: PlaceDetailResponse | null) =>
     set(() => ({
       placeDetail: placeDetail,
     })),


### PR DESCRIPTION
## 📌 작업 개요
- map페이지 컴포넌트에 이전 데이터 남아있다가 전환되는 문제 수정


## ✨ 주요 변경 사항
- 인근 장소 조회 시, 이전 데이터가 남아있다가 전환되는 문제 수정
- 유저의 그룹리스트 조회 시, 이전 데이터가 남아있다가 전환되는 문제 수정그룹의 즐겨찾기 조회 시
- 이전 데이터가 남아있다가 전환되는 문제 수정
- 모두 뒤로가기 버튼에서 데이터 초기화하도록 하였습니다.


## 🖼️ 스크린샷 (선택)


## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
- npm run build 통과



## 💬 기타 참고 사항
- 멘토님한테 물어봤던 부분! 뒤로가기 버튼 클릭 시, 이전 데이터 초기화로 구현했습니다.
- close #108 
