### PR TITLE
카카오 로그아웃 구현 및 버그 수정

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -12,12 +12,12 @@ const handler = NextAuth({
     }),
   ],
   secret: process.env.NEXTAUTH_SECRET,
+  session: {
+    strategy: "jwt",
+  },
   callbacks: {
     async jwt({ token, account }) {
       if (account) {
-        token.accessToken = account.access_token;
-        console.log("account", account);
-
         // 백엔드에 소셜 로그인 요청
         const response = await fetch(`${API_BASE_URL}/auth/signin/kakao`, {
           method: "POST",
@@ -34,12 +34,16 @@ const handler = NextAuth({
         }
         token.accessToken = result.data.accessToken;
         token.refreshToken = result.data.refreshToken;
+        token.kakaoAccessToken = account.access_token;
       }
       return token;
     },
     async session({ session, token }) {
       if (token) {
-        session.user.accessToken = token.accessToken as string;
+        session.user = {
+          accessToken: token.accessToken as string,
+          kakaoAccessToken: token.kakaoAccessToken as string,
+        };
 
         await saveAuthCookies({
           accessToken: token.accessToken as string,

--- a/src/app/api/auth/unlink/route.ts
+++ b/src/app/api/auth/unlink/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const { kakaoAccessToken } = await req.json();
+
+  const res = await fetch("https://kapi.kakao.com/v1/user/unlink", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${kakaoAccessToken}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+  });
+
+  if (!res.ok) {
+    const error = await res.text();
+    console.error("카카오 unlink 실패:", error);
+    return NextResponse.json({ success: false, error }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/components/AuthInitializer.tsx
+++ b/src/components/AuthInitializer.tsx
@@ -8,17 +8,17 @@ import { useEffect } from "react";
 
 const AuthInitializer = ({ children }: { children: React.ReactNode }) => {
   const pathName = usePathname();
-  const { isInitialized, setUser, clearUser } = useAuthStore();
+  const { isSocialLogin, setUser, clearUser } = useAuthStore();
   const { status, data: session } = useSession();
   const { data, error, refetch } = useUser({ enabled: false });
 
   useEffect(() => {
     if (pathName.includes("login") || pathName.includes("signup")) return;
 
-    if (status === "authenticated" && isInitialized) {
+    if (status === "authenticated" && isSocialLogin) {
       refetch(); // 세션 존재 시 유저 정보 요청
     }
-  }, [status, refetch, pathName, isInitialized, session?.user?.accessToken]);
+  }, [status, refetch, pathName, isSocialLogin, session?.user?.accessToken]);
 
   useEffect(() => {
     if (data) setUser(data);

--- a/src/components/AuthInitializer.tsx
+++ b/src/components/AuthInitializer.tsx
@@ -8,17 +8,17 @@ import { useEffect } from "react";
 
 const AuthInitializer = ({ children }: { children: React.ReactNode }) => {
   const pathName = usePathname();
-  const { setUser, clearUser } = useAuthStore();
+  const { isInitialized, setUser, clearUser } = useAuthStore();
   const { status, data: session } = useSession();
   const { data, error, refetch } = useUser({ enabled: false });
 
   useEffect(() => {
     if (pathName.includes("login") || pathName.includes("signup")) return;
 
-    if (status === "authenticated" && session?.user?.accessToken) {
+    if (status === "authenticated" && isInitialized) {
       refetch(); // 세션 존재 시 유저 정보 요청
     }
-  }, [status, refetch, pathName, session?.user?.accessToken]);
+  }, [status, refetch, pathName, isInitialized, session?.user?.accessToken]);
 
   useEffect(() => {
     if (data) setUser(data);

--- a/src/components/auth/LoginForm/useLoginForm.ts
+++ b/src/components/auth/LoginForm/useLoginForm.ts
@@ -18,7 +18,7 @@ interface LoginFormErrors {
 
 const useLoginForm = () => {
   const router = useRouter();
-  const { setUser, setInitialized } = useAuthStore();
+  const { setUser, setIsSocialLogin } = useAuthStore();
 
   const [formState, setFormState] = useState({
     email: "",
@@ -88,14 +88,14 @@ const useLoginForm = () => {
 
   const handleKakaoLogin = async () => {
     try {
-      setInitialized(true);
+      setIsSocialLogin(true);
       await signIn("kakao", {
         redirect: true,
         callbackUrl: "/",
       });
     } catch (error) {
       console.error("카카오 로그인 중 에러", error);
-      setInitialized(false);
+      setIsSocialLogin(false);
       showToastMessage({
         type: "error",
         message: "카카오 로그인 중 오류가 발생했습니다.",

--- a/src/components/auth/LoginForm/useLoginForm.ts
+++ b/src/components/auth/LoginForm/useLoginForm.ts
@@ -18,7 +18,7 @@ interface LoginFormErrors {
 
 const useLoginForm = () => {
   const router = useRouter();
-  const { setUser } = useAuthStore();
+  const { setUser, setInitialized } = useAuthStore();
 
   const [formState, setFormState] = useState({
     email: "",
@@ -88,12 +88,14 @@ const useLoginForm = () => {
 
   const handleKakaoLogin = async () => {
     try {
+      setInitialized(true);
       await signIn("kakao", {
         redirect: true,
         callbackUrl: "/",
       });
     } catch (error) {
       console.error("카카오 로그인 중 에러", error);
+      setInitialized(false);
       showToastMessage({
         type: "error",
         message: "카카오 로그인 중 오류가 발생했습니다.",

--- a/src/components/layout/Sidebar/Sidebar.tsx
+++ b/src/components/layout/Sidebar/Sidebar.tsx
@@ -9,9 +9,8 @@ import SidebarButtonList from "@/components/common/SidebarButton/SidebarButtonLi
 import { LogIn, LogOut } from "lucide-react";
 import { useAuthStore } from "@/stores/useAuthStore";
 import SidebarButton from "@/components/common/SidebarButton/SidebarButton";
-import { logout } from "@/lib/api/auth";
-import { useRouter } from "next/navigation";
 import { useToastMessageContext } from "@/providers/ToastMessageProvider";
+import { useLogout } from "@/hooks/useUser";
 
 interface SidebarProps {
   isOpen: boolean;
@@ -21,8 +20,8 @@ interface SidebarProps {
 const Sidebar = ({ isOpen, onClose }: SidebarProps) => {
   const [visible, setVisible] = useState(isOpen);
   const { user } = useAuthStore();
-  const router = useRouter();
   const { showToastMessage } = useToastMessageContext();
+  const { logout } = useLogout();
 
   useEffect(() => {
     if (isOpen) setVisible(true);
@@ -34,17 +33,15 @@ const Sidebar = ({ isOpen, onClose }: SidebarProps) => {
 
   const handleLogout = async () => {
     try {
-      await logout();
-    } catch {
+      await logout("/login");
+    } catch (error) {
+      console.log(error);
       showToastMessage({
         type: "error",
         message: "로그아웃에 실패했습니다. 다시 시도해주세요.",
       });
       return;
     }
-    useAuthStore.getState().clearUser();
-    onClose();
-    router.push("/");
   };
 
   return (

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -22,7 +22,7 @@ export const useUser = (options?: { enabled?: boolean }) => {
 };
 
 export const useLogout = () => {
-  const { clearUser, setInitialized } = useAuthStore();
+  const { clearUser, setIsSocialLogin } = useAuthStore();
 
   const logout = async (callbackUrl: string = "/") => {
     clearUser(); // 상태 초기화
@@ -45,7 +45,7 @@ export const useLogout = () => {
 
     deleteCookie("access_token");
     deleteCookie("refresh_token");
-    setInitialized(false);
+    setIsSocialLogin(false);
     await signOut({ callbackUrl });
   };
 

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -22,7 +22,7 @@ export const useUser = (options?: { enabled?: boolean }) => {
 };
 
 export const useLogout = () => {
-  const { clearUser } = useAuthStore();
+  const { clearUser, setInitialized } = useAuthStore();
 
   const logout = async (callbackUrl: string = "/") => {
     clearUser(); // 상태 초기화
@@ -45,6 +45,7 @@ export const useLogout = () => {
 
     deleteCookie("access_token");
     deleteCookie("refresh_token");
+    setInitialized(false);
     await signOut({ callbackUrl });
   };
 

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -1,7 +1,6 @@
 import { AuthCredentials, SignupCredentials } from "@/types/auth";
 import { client } from "../fetch/client";
 import { UserInfo } from "@/stores/useAuthStore";
-import { getCookie } from "cookies-next";
 
 export const userSignup = async (
   credentials: SignupCredentials,
@@ -95,15 +94,4 @@ export const resetPassword = async (
 
 export const fetchUser = async (): Promise<UserInfo> => {
   return await client<UserInfo>("/api/users/my");
-};
-
-// 로그아웃
-export const logout = async () => {
-  const accessToken = getCookie("access_token");
-  await fetch("/api/auth/signout", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
 };

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -40,11 +40,11 @@ export interface UserInfo {
 interface AuthState {
   user: UserInfo | null;
   accessToken: string | null;
-  isInitialized: boolean;
+  isSocialLogin: boolean;
   setUser: (user: UserInfo | null) => void;
   setAccessToken: (token: string | null) => void;
   clearUser: () => void;
-  setInitialized: (state: boolean) => void;
+  setIsSocialLogin: (state: boolean) => void;
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -55,12 +55,12 @@ export const useAuthStore = create<AuthState>()(
         typeof window !== "undefined"
           ? (getCookie("access_token")?.toString() ?? null)
           : null,
-      isInitialized: false,
+      isSocialLogin: false,
 
       setUser: (user) => set({ user }),
       clearUser: () => set({ user: null, accessToken: null }),
       setAccessToken: (token) => set({ accessToken: token }),
-      setInitialized: (state) => set({ isInitialized: state }),
+      setIsSocialLogin: (state) => set({ isSocialLogin: state }),
     }),
     {
       name: "auth-storage",
@@ -68,7 +68,7 @@ export const useAuthStore = create<AuthState>()(
         // 저장할 필드만 지정
         user: state.user,
         accessToken: state.accessToken,
-        isInitialized: state.isInitialized,
+        isSocialLogin: state.isSocialLogin,
       }),
     },
   ),

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -44,7 +44,7 @@ interface AuthState {
   setUser: (user: UserInfo | null) => void;
   setAccessToken: (token: string | null) => void;
   clearUser: () => void;
-  setInitialized: () => void;
+  setInitialized: (state: boolean) => void;
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -60,7 +60,7 @@ export const useAuthStore = create<AuthState>()(
       setUser: (user) => set({ user }),
       clearUser: () => set({ user: null, accessToken: null }),
       setAccessToken: (token) => set({ accessToken: token }),
-      setInitialized: () => set({ isInitialized: true }),
+      setInitialized: (state) => set({ isInitialized: state }),
     }),
     {
       name: "auth-storage",
@@ -68,6 +68,7 @@ export const useAuthStore = create<AuthState>()(
         // 저장할 필드만 지정
         user: state.user,
         accessToken: state.accessToken,
+        isInitialized: state.isInitialized,
       }),
     },
   ),

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -6,10 +6,12 @@ declare module "next-auth" {
       accessToken?: string;
       image?: string;
       name?: string;
+      kakaoAccessToken?: string;
     };
   }
 
   interface User {
     accessToken?: string;
+    kakaoAccessToken?: string;
   }
 }


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
카카오 로그아웃 구현 및 버그 수정

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 카카오 로그아웃을 구현했습니다.
- 카카오 로그아웃 후 홈화면 진입 시 로그인화면으로 이동하는 버그를 수정했습니다.

 AuthInitializer에서 session?.user?.accessToken 이 있으면 데이터를 받아오게 해놨었는데 로그아웃을 해도 session이 지워지지 않는 이슈가 있었습니다. "next-auth.session-token" 라는 키가 사라지면 되는데 httpOnly라 js에서 제거도 불가능해서 zustand에 있는 isSocialLogin를 사용해 소셜 로그인 일 경우에만 데이터를 받아오도록 수정했습니다.



## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->



## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [ ] 변수명, 함수명 명확하게 작성
- [ ] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->
카카오 로그인 -> 로그아웃 -> 홈화면으로 이동
재현되지 않음 확인

## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
"next-auth/react" 의 signOut을 쓰면 된다고 했는데.. 지피티도 그렇고, next-auth의 깃헙 이슈에도 동일한 현상을 가지신 분들이 많더라고요 ㅎㅎ..
이게 현재의 최선입니다.. ㅠㅠ