### PR TITLE
fix/sse : useLoginForm에서의 토큰 전역저장 코드 복구

### DIFF
--- a/src/components/auth/LoginForm/useLoginForm.ts
+++ b/src/components/auth/LoginForm/useLoginForm.ts
@@ -8,6 +8,7 @@ import { validateEmail, validatePassword } from "@/utils/validate";
 import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { ChangeEvent, FormEvent, useCallback, useState } from "react";
+import { getCookie } from "cookies-next";
 
 type FormType = "email" | "password";
 
@@ -74,6 +75,13 @@ const useLoginForm = () => {
       const user = await fetchUser();
       setUser(user);
 
+      const accessToken = getCookie("access_token"); // 쿠키에서 꺼내서
+      if (accessToken && typeof accessToken === "string") {
+        useAuthStore.getState().setAccessToken(accessToken); // 전역 저장
+      } else {
+        console.warn("accessToken이 쿠키에 없음");
+      }
+
       router.replace("/");
     } catch (err) {
       showToastMessage({ type: "error", message: getErrorMessage(err) });
@@ -100,6 +108,12 @@ const useLoginForm = () => {
         type: "error",
         message: "카카오 로그인 중 오류가 발생했습니다.",
       });
+    }
+    const accessToken = getCookie("access_token"); // 쿠키에서 꺼내서
+    if (accessToken && typeof accessToken === "string") {
+      useAuthStore.getState().setAccessToken(accessToken); // 전역 저장
+    } else {
+      console.warn("accessToken이 쿠키에 없음");
     }
   };
 


### PR DESCRIPTION
## 📌 작업 개요

- useLoginForm에서 토큰 전역저장 코드 되살림

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- accessToken이 zustand에 저장되지 않아 SSE 연결이 실패하던 문제를 해결
  - #149 에서 setToken을 useAuthStore에서 실행하도록 바꾸셨었는데, 이 경우 useSse 진입 시점에 zustand에 토큰 저장이 되지 않았더라구요...!
  - 로그인 시점에서 useLoginForm 내부에서 쿠키에 저장된 accessToken을 직접 꺼내어 전역 상태에 저장하도록 수정했습니다 (이전 코드 일부)

## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
> 변경 전 로그인 직후 콘솔로그
![image](https://github.com/user-attachments/assets/232030d8-0e3a-4745-9285-d88aae87f948)

> 변경 이후 로그인 직후 콘솔로그 : useSse 진입 시점 토큰 찍힘+연결시도 정상
![image](https://github.com/user-attachments/assets/09c7bf36-508d-423a-8a46-da5e103e8a34)


## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [ ] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->
- local3000 <-> ec2


## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
- @mini0212 님 변경코드 부분이라 검토 부탁드립니다!