### PR TITLE
즐겨찾기 그룹 조회 버그 수정과 카카오톡 공유하기 기능 구현 및 사용자 UX 개선

### DIFF
--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -22,7 +22,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
         </Suspense>
       </AppErrorBoundary>
       <div className="flex flex-col max-w-3xl mx-auto">
-        <ProfileTabClient />
+        <ProfileTabClient userId={userId} />
       </div>
     </div>
   );

--- a/src/components/Favorite/FavoriteGroupCard.tsx
+++ b/src/components/Favorite/FavoriteGroupCard.tsx
@@ -13,11 +13,13 @@ import {
 interface FavoriteGroupProps {
   group: FavoriteGroupType;
   onDelete: (groupId: number) => void;
+  isOwner: boolean;
 }
 
 export default function FavoriteGroupCard({
   group,
   onDelete,
+  isOwner,
 }: FavoriteGroupProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -107,15 +109,15 @@ export default function FavoriteGroupCard({
           </span>
         </div>
       </div>
-
-      <button
-        className="text-gray600 hover:text-black"
-        onClick={() => setIsMenuOpen((prev) => !prev)}
-        ref={buttonRef}
-      >
-        <MoreVerticalIcon width={20} height={20} />
-      </button>
-
+      {isOwner && (
+        <button
+          className="text-gray600 hover:text-black"
+          onClick={() => setIsMenuOpen((prev) => !prev)}
+          ref={buttonRef}
+        >
+          <MoreVerticalIcon width={20} height={20} />
+        </button>
+      )}
       {/* 메뉴 팝업 */}
       {isMenuOpen && (
         <div

--- a/src/components/Favorite/FavoriteGroupList.tsx
+++ b/src/components/Favorite/FavoriteGroupList.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useAuthStore } from "@/stores/useAuthStore";
 import { useFavoriteGroups } from "@/hooks/useFavorite";
 import type { FavoriteGroupType } from "@/types/favorite";
 import { createFavoriteGroup } from "@/lib/api/favorite";
@@ -12,10 +11,7 @@ import FallbackMessage from "../common/Fallback/FallbackMessage";
 import AddFavoriteGroupModal from "./AddFavoriteGroupModal";
 import { useToastMessageContext } from "@/providers/ToastMessageProvider";
 
-export default function FavoriteGroupList() {
-  const { user } = useAuthStore();
-  const userId = user?.userId ?? null;
-
+export default function FavoriteGroupList({ userId }: { userId: string }) {
   const { data: groups, isLoading } = useFavoriteGroups(userId);
   const [groupList, setGroupList] = useState<FavoriteGroupType[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/src/components/Favorite/FavoriteGroupList.tsx
+++ b/src/components/Favorite/FavoriteGroupList.tsx
@@ -10,12 +10,15 @@ import AppErrorBoundary from "../common/ErrorBoundary/ErrorBoundary";
 import FallbackMessage from "../common/Fallback/FallbackMessage";
 import AddFavoriteGroupModal from "./AddFavoriteGroupModal";
 import { useToastMessageContext } from "@/providers/ToastMessageProvider";
+import { useAuthStore } from "@/stores/useAuthStore";
 
 export default function FavoriteGroupList({ userId }: { userId: string }) {
   const { data: groups, isLoading } = useFavoriteGroups(userId);
   const [groupList, setGroupList] = useState<FavoriteGroupType[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { showToastMessage } = useToastMessageContext();
+  const { user } = useAuthStore();
+  const isMyProfile = user?.userId?.toString() === userId;
 
   // 초기 값을 setGroupList를 통해 useState 로 저장
   useEffect(() => {
@@ -59,17 +62,25 @@ export default function FavoriteGroupList({ userId }: { userId: string }) {
     <AppErrorBoundary fallbackMessage="즐겨찾기 그룹을 불러오는 중 오류가 발생했습니다.">
       <div className="space-y-2">
         {/* 그룹 추가 버튼 */}
-        <div className="flex justify-end mb-2">
-          <button onClick={() => setIsModalOpen(true)} className="text-gray900">
-            + 그룹 추가
-          </button>
-        </div>
-
+        {isMyProfile && (
+          <div className="flex justify-end mb-2">
+            <button
+              onClick={() => setIsModalOpen(true)}
+              className="text-gray900"
+            >
+              + 그룹 추가
+            </button>
+          </div>
+        )}
         {/* 즐겨찾기 그룹 리스트 */}
         <ul className="space-y-2">
           {groupList.map((group) => (
             <li key={group.groupId}>
-              <FavoriteGroupCard group={group} onDelete={handleDeleteGroup} />
+              <FavoriteGroupCard
+                group={group}
+                onDelete={handleDeleteGroup}
+                isOwner={isMyProfile}
+              />
             </li>
           ))}
         </ul>

--- a/src/components/Favorite/FavoriteItemCard.tsx
+++ b/src/components/Favorite/FavoriteItemCard.tsx
@@ -5,6 +5,7 @@ import type { FavoriteItemType } from "@/types/favorite";
 import { MoreVerticalIcon } from "lucide-react";
 import { updateFavoriteItem, deleteFavoriteItem } from "@/lib/api/favorite";
 import ConfirmDeleteModal from "./ConfirmDeleteModal";
+import { useAuthStore } from "@/stores/useAuthStore";
 
 interface Props {
   item: FavoriteItemType;
@@ -21,6 +22,9 @@ export default function FavoriteItemCard({ item, onDelete }: Props) {
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const { user } = useAuthStore();
+  const isOwner = user?.userId === item.userId;
 
   // 외부 클릭 시 메뉴 닫기
   useEffect(() => {
@@ -66,15 +70,15 @@ export default function FavoriteItemCard({ item, onDelete }: Props) {
           {item.placeName}
           <span className="font-normal text-gray600 ml-4">{item.address}</span>
         </div>
-
-        <button
-          className="text-gray600 hover:text-black"
-          onClick={() => setIsMenuOpen((prev) => !prev)}
-          ref={buttonRef}
-        >
-          <MoreVerticalIcon width={20} height={20} />
-        </button>
-
+        {isOwner && (
+          <button
+            className="text-gray600 hover:text-black"
+            onClick={() => setIsMenuOpen((prev) => !prev)}
+            ref={buttonRef}
+          >
+            <MoreVerticalIcon width={20} height={20} />
+          </button>
+        )}
         {isMenuOpen && (
           <div
             ref={menuRef}

--- a/src/components/Home/Map/HotPlaceList.tsx
+++ b/src/components/Home/Map/HotPlaceList.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { CategoryType } from "@/types/map";
 import { useHotPlace } from "@/hooks/useHotPlace";
+import { useAuthStore } from "@/stores/useAuthStore";
 import HotPlaceHeader from "./HotPlaceHeader";
 import PlaceCard from "@/components/map/PlaceCard";
 import FallbackMessage from "@/components/common/Fallback/FallbackMessage";
@@ -18,6 +19,8 @@ export default function HotPlaceList() {
     radiusKm: 10, // 주변 장소 조회 반경 입력
     maxResults: 20, // 주변 장소 조회 리스트 개수 입력
   });
+
+  const { user } = useAuthStore(); // 로그인 유저 정보
 
   return (
     <div className="flex flex-col gap-2">
@@ -52,8 +55,10 @@ export default function HotPlaceList() {
           ))}
         </div>
       ) : (
-        <div className="flex min-w-[400px] h-[280px] justify-center items-center">
-          <FallbackMessage message="근처에 장소가 없습니다." />
+        <div className="flex sm:min-w-[400px] h-[280px] justify-center items-center">
+          <FallbackMessage
+            message={user ? "근처에 장소가 없습니다." : "로그인이 필요합니다."}
+          />
         </div>
       )}
     </div>

--- a/src/components/Profile/ProfileTab/ProfileTabClient.tsx
+++ b/src/components/Profile/ProfileTab/ProfileTabClient.tsx
@@ -5,13 +5,13 @@ import ProfileTabs from "./ProfileTabs";
 import ProfileTabContent from "./ProfileTabContent";
 import { ProfileTabType } from "@/types/profile";
 
-const ProfileTabClient = () => {
+const ProfileTabClient = ({ userId }: { userId: string }) => {
   const [activeTab, setActiveTab] = useState<ProfileTabType>("posts");
 
   return (
     <div>
       <ProfileTabs activeTab={activeTab} onTabChange={setActiveTab} />
-      <ProfileTabContent activeTab={activeTab} />
+      <ProfileTabContent activeTab={activeTab} userId={userId} />
     </div>
   );
 };

--- a/src/components/Profile/ProfileTab/ProfileTabContent.tsx
+++ b/src/components/Profile/ProfileTab/ProfileTabContent.tsx
@@ -7,9 +7,10 @@ import AppErrorBoundary from "@/components/common/ErrorBoundary/ErrorBoundary";
 
 interface Props {
   activeTab: ProfileTabType;
+  userId: string;
 }
 
-export default function ProfileTabContent({ activeTab }: Props) {
+export default function ProfileTabContent({ activeTab, userId }: Props) {
   const isPostRelatedTab = ["posts", "comments", "likes"].includes(activeTab);
 
   if (isPostRelatedTab) {
@@ -32,7 +33,7 @@ export default function ProfileTabContent({ activeTab }: Props) {
   if (activeTab === "favorites") {
     return (
       <div className="mt-4">
-        <FavoriteGroupList />
+        <FavoriteGroupList userId={userId} />
       </div>
     );
   }

--- a/src/components/editor/EditorActions.tsx
+++ b/src/components/editor/EditorActions.tsx
@@ -47,7 +47,7 @@ export default function EditorActions({
       </BaseButton>
       <BaseButton
         type="button"
-        color="skyblue300"
+        color="violet800"
         onClick={onSubmit}
         className="h-[44px] w-[120px] text-nowrap mt-4"
       >

--- a/src/components/post/PostFooter.tsx
+++ b/src/components/post/PostFooter.tsx
@@ -4,6 +4,7 @@ import { MessageCircle, Heart } from "lucide-react";
 import { ShareIcon } from "../common/Icons";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useKakaoInit } from "@/hooks/useKakaoInit";
 import ShareModal from "./ShareModal";
 
 interface PostFooterProps {
@@ -34,7 +35,8 @@ export default function PostFooter({
   // 글 작성자와 로그인 유저가 같은 지 확인
   const isMine = currentUserId === authorUserId;
 
-  // 공유 하기 모달
+  // 카카오 공유 sdk
+  useKakaoInit();
 
   // 신고 하기
   const handleReport = () => {

--- a/src/components/post/PostFooter.tsx
+++ b/src/components/post/PostFooter.tsx
@@ -2,8 +2,9 @@
 
 import { MessageCircle, Heart } from "lucide-react";
 import { ShareIcon } from "../common/Icons";
-import { useToastMessageContext } from "@/providers/ToastMessageProvider";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
+import ShareModal from "./ShareModal";
 
 interface PostFooterProps {
   postId: number;
@@ -26,27 +27,14 @@ export default function PostFooter({
   authorUserId,
   currentUserId,
 }: PostFooterProps) {
-  const { showToastMessage } = useToastMessageContext();
+  const [openShareModal, setOpenShareModal] = useState(false);
   const router = useRouter();
+  
 
   // 글 작성자와 로그인 유저가 같은 지 확인
   const isMine = currentUserId === authorUserId;
 
-  // 공유하기
-  const handleShare = async () => {
-    try {
-      await navigator.clipboard.writeText(window.location.href);
-      showToastMessage({
-        message: "URL이 복사되었습니다.",
-        type: "success",
-      });
-    } catch {
-      showToastMessage({
-        message: "URL 복사에 실패하였습니다.",
-        type: "error",
-      });
-    }
-  };
+  // 공유 하기 모달
 
   // 신고 하기
   const handleReport = () => {
@@ -68,7 +56,7 @@ export default function PostFooter({
           <MessageCircle size={20} />
           <span>{commentCount}</span>
         </div>
-        <button onClick={handleShare} className="flex items-center gap-2">
+        <button onClick={() => setOpenShareModal(true)} className="flex items-center gap-2">
           <ShareIcon />
           <span>공유하기</span>
         </button>
@@ -83,6 +71,7 @@ export default function PostFooter({
           </button>
         </div>
       )}
+      {openShareModal && <ShareModal onClose={() => setOpenShareModal(false)} />}
     </div>
   );
 }

--- a/src/components/post/ShareModal.tsx
+++ b/src/components/post/ShareModal.tsx
@@ -1,11 +1,22 @@
 "use client";
 
 import { shareToKakao } from "@/utils/shareToKakao";
+import { useEffect } from "react";
 import { useToastMessageContext } from "@/providers/ToastMessageProvider";
+import { KakaoIcon } from "@/components/common/Icons";
+import { Link, X } from "lucide-react";
 
 export default function ShareModal({ onClose }: { onClose: () => void }) {
   const url = typeof window !== "undefined" ? window.location.href : "";
   const { showToastMessage } = useToastMessageContext();
+
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+  
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, []);
 
   const handleCopy = async () => {
     try {
@@ -40,22 +51,33 @@ export default function ShareModal({ onClose }: { onClose: () => void }) {
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white p-4 rounded shadow w-80">
-        <h2 className="text-lg font-bold mb-4">공유하기</h2>
-        <div className="flex flex-col gap-3">
-          <button onClick={handleCopy} className="bg-gray-200 p-2 rounded">
-            🔗 URL 복사
+      <div className="relative w-80 bg-white p-4 rounded-xl shadow">
+        {/* 닫기 X 버튼 */}
+        <button onClick={onClose} className="absolute top-4 right-4">
+          <X size={20} className="text-gray900 hover:text-gray900/80" />
+        </button>
+
+        <h2 className="text-lg font-bold mb-2 text-center">공유하기</h2>
+        <div className="flex flex-col gap-2">
+          <button
+            onClick={handleCopy}
+            className="relative flex justify-center items-center p-2 bg-gray200 hover:bg-gray200/80 rounded-lg font-bold text-gray900"
+          >
+            <span className="absolute left-4 top-1/2 -translate-y-1/2">
+              <Link />
+            </span>
+            <span>URL 복사</span>
           </button>
           <button
             onClick={handleKakaoShare}
-            className="bg-yellow-300 p-2 rounded"
+            className="relative flex justify-center items-center p-2 bg-kakao hover:bg-kakao/80 rounded-lg font-bold text-gray900"
           >
-            🟡 카카오톡 공유
+            <span className="absolute left-4 top-1/2 -translate-y-1/2">
+              <KakaoIcon />
+            </span>
+            <span>카카오톡 공유</span>
           </button>
         </div>
-        <button className="text-sm text-gray-500 mt-4" onClick={onClose}>
-          닫기
-        </button>
       </div>
     </div>
   );

--- a/src/components/post/ShareModal.tsx
+++ b/src/components/post/ShareModal.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import Script from "next/script";
 import { shareToKakao } from "@/utils/shareToKakao";
 import { useToastMessageContext } from "@/providers/ToastMessageProvider";
-import { useState } from "react";
 
 export default function ShareModal({ onClose }: { onClose: () => void }) {
   const url = typeof window !== "undefined" ? window.location.href : "";
   const { showToastMessage } = useToastMessageContext();
-  const [isKakaoReady, setIsKakaoReady] = useState(false);
 
   const handleCopy = async () => {
     try {
@@ -24,7 +21,7 @@ export default function ShareModal({ onClose }: { onClose: () => void }) {
   };
 
   const handleKakaoShare = () => {
-    if (!isKakaoReady) {
+    if (!window.Kakao?.isInitialized()) {
       showToastMessage({
         message: "공유 SDK가 아직 로드되지 않았습니다.",
         type: "error",
@@ -42,39 +39,24 @@ export default function ShareModal({ onClose }: { onClose: () => void }) {
   };
 
   return (
-    <>
-      <Script
-        src="https://developers.kakao.com/sdk/js/kakao.min.js"
-        strategy="lazyOnload"
-        onLoad={() => {
-          if (window.Kakao && !window.Kakao.isInitialized()) {
-            window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID!);
-            console.log("Kakao 공유 SDK 초기화 완료");
-          }
-          setIsKakaoReady(true); // SDK 준비 완료 상태 업데이트
-        }}
-      />
-
-      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-        <div className="bg-white p-4 rounded shadow w-80">
-          <h2 className="text-lg font-bold mb-4">공유하기</h2>
-          <div className="flex flex-col gap-3">
-            <button onClick={handleCopy} className="bg-gray-200 p-2 rounded">
-              🔗 URL 복사
-            </button>
-            <button
-              onClick={handleKakaoShare}
-              className={`bg-yellow-300 p-2 rounded ${!isKakaoReady && "opacity-50 cursor-not-allowed"}`}
-              disabled={!isKakaoReady}
-            >
-              🟡 카카오톡 공유
-            </button>
-          </div>
-          <button className="text-sm text-gray-500 mt-4" onClick={onClose}>
-            닫기
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white p-4 rounded shadow w-80">
+        <h2 className="text-lg font-bold mb-4">공유하기</h2>
+        <div className="flex flex-col gap-3">
+          <button onClick={handleCopy} className="bg-gray-200 p-2 rounded">
+            🔗 URL 복사
+          </button>
+          <button
+            onClick={handleKakaoShare}
+            className="bg-yellow-300 p-2 rounded"
+          >
+            🟡 카카오톡 공유
           </button>
         </div>
+        <button className="text-sm text-gray-500 mt-4" onClick={onClose}>
+          닫기
+        </button>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/post/ShareModal.tsx
+++ b/src/components/post/ShareModal.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Script from "next/script";
+import { shareToKakao } from "@/utils/shareToKakao";
+import { useToastMessageContext } from "@/providers/ToastMessageProvider";
+import { useState } from "react";
+
+export default function ShareModal({ onClose }: { onClose: () => void }) {
+  const url = typeof window !== "undefined" ? window.location.href : "";
+  const { showToastMessage } = useToastMessageContext();
+  const [isKakaoReady, setIsKakaoReady] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      showToastMessage({ message: "URL이 복사되었습니다.", type: "success" });
+      onClose();
+    } catch {
+      showToastMessage({
+        message: "URL 복사에 실패하였습니다.",
+        type: "error",
+      });
+    }
+  };
+
+  const handleKakaoShare = () => {
+    if (!isKakaoReady) {
+      showToastMessage({
+        message: "공유 SDK가 아직 로드되지 않았습니다.",
+        type: "error",
+      });
+      return;
+    }
+
+    shareToKakao({
+      title: "🔥 핫한 게시물",
+      description: "이 글을 공유해보세요!",
+      imageUrl: "https://placehold.co/600x400",
+      link: url,
+    });
+    onClose();
+  };
+
+  return (
+    <>
+      <Script
+        src="https://developers.kakao.com/sdk/js/kakao.min.js"
+        strategy="lazyOnload"
+        onLoad={() => {
+          if (window.Kakao && !window.Kakao.isInitialized()) {
+            window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID!);
+            console.log("Kakao 공유 SDK 초기화 완료");
+          }
+          setIsKakaoReady(true); // SDK 준비 완료 상태 업데이트
+        }}
+      />
+
+      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+        <div className="bg-white p-4 rounded shadow w-80">
+          <h2 className="text-lg font-bold mb-4">공유하기</h2>
+          <div className="flex flex-col gap-3">
+            <button onClick={handleCopy} className="bg-gray-200 p-2 rounded">
+              🔗 URL 복사
+            </button>
+            <button
+              onClick={handleKakaoShare}
+              className={`bg-yellow-300 p-2 rounded ${!isKakaoReady && "opacity-50 cursor-not-allowed"}`}
+              disabled={!isKakaoReady}
+            >
+              🟡 카카오톡 공유
+            </button>
+          </div>
+          <button className="text-sm text-gray-500 mt-4" onClick={onClose}>
+            닫기
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/hooks/useFavorite.ts
+++ b/src/hooks/useFavorite.ts
@@ -2,12 +2,12 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchFavoriteGroups, fetchFavoriteItems } from "@/lib/api/favorite";
 
 // 즐겨찾기 그룹 리스트 가져오기
-export const useFavoriteGroups = (userId: number | null) => {
+export const useFavoriteGroups = (userId: string | null) => {
   return useQuery({
     queryKey: ["favoriteGroups", userId],
     queryFn: () => {
       if (!userId) throw new Error("userId가 없습니다");
-      return fetchFavoriteGroups(userId);
+      return fetchFavoriteGroups(Number(userId));
     },
     enabled: !!userId,
     staleTime: 1000 * 60 * 5,

--- a/src/hooks/useKakaoInit.ts
+++ b/src/hooks/useKakaoInit.ts
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+
+export const useKakaoInit = () => {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    if (window.Kakao && window.Kakao.isInitialized?.()) {
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = "https://developers.kakao.com/sdk/js/kakao.min.js";
+    script.async = true;
+    script.onload = () => {
+      if (window.Kakao && !window.Kakao.isInitialized()) {
+        window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID!);
+        console.log("Kakao SDK 초기화 완료");
+      }
+    };
+
+    document.head.appendChild(script);
+  }, []);
+};

--- a/src/types/kakao.d.ts
+++ b/src/types/kakao.d.ts
@@ -1,0 +1,31 @@
+declare global {
+  interface Window {
+    Kakao: {
+      isInitialized: () => boolean;
+      init: (key: string) => void;
+      Link: {
+        sendDefault: (options: {
+          objectType: "feed";
+          content: {
+            title: string;
+            description: string;
+            imageUrl: string;
+            link: {
+              mobileWebUrl: string;
+              webUrl: string;
+            };
+          };
+          buttons?: {
+            title: string;
+            link: {
+              mobileWebUrl: string;
+              webUrl: string;
+            };
+          }[];
+        }) => void;
+      };
+    };
+  }
+}
+
+export {};

--- a/src/utils/shareToKakao.ts
+++ b/src/utils/shareToKakao.ts
@@ -1,0 +1,53 @@
+export const shareToKakao = ({
+  title,
+  description,
+  imageUrl,
+  link,
+}: {
+  title: string;
+  description: string;
+  imageUrl: string;
+  link: string;
+}) => {
+  if (!window.Kakao) {
+    console.warn("Kakao SDK가 아직 로드되지 않았습니다.");
+    return;
+  }
+
+  if (!window.Kakao.isInitialized()) {
+    try {
+      window.Kakao.init(process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID!);
+      console.log("공유 시점에 Kakao SDK 초기화");
+    } catch (e) {
+      console.error("Kakao.init() 실패", e);
+      return;
+    }
+  }
+
+  try {
+    window.Kakao.Link.sendDefault({
+      objectType: "feed",
+      content: {
+        title,
+        description,
+        imageUrl,
+        link: {
+          mobileWebUrl: link,
+          webUrl: link,
+        },
+      },
+      buttons: [
+        {
+          title: "자세히 보기",
+          link: {
+            mobileWebUrl: link,
+            webUrl: link,
+          },
+        },
+      ],
+    });
+    console.log("✅ Kakao 공유창 실행");
+  } catch (error) {
+    console.error("❌ Kakao 공유 실패", error);
+  }
+};


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
즐겨찾기 그룹 조회 버그 수정과 카카오톡 공유하기 기능 구현 및 사용자 UX 개선

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 글쓰기 에디터에서 등록 버튼 색상이 변경되었습니다 (violet800)
- 다른 사용자의 프로필에서 해당 사용자의 즐겨찾기 그룹이 조회되도록 수정했습니다
- 다른 사용자의 즐겨찾기 그룹 리스트에서 그룹 추가와 메뉴 버튼이 보이지 않게 수정했습니다
- 다른 사용자의 즐겨찾기 장소 리스트에서 메뉴 버튼이 보이지 않게 수정했습니다
- 핫플레이스 리스트 FallbackMessage 가 비로그인 사용자일 경우 로그인 관련 메세지가 나오게 분기처리 했습니다 
- 게시글 카카오톡 공유하기 기능과 이를 선택할 수 있는 모달을 구현했습니다

## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/f6630307-8298-4b1d-8937-3e20fe547bbd)
에디터 등록 버튼 색상 변경

![image](https://github.com/user-attachments/assets/989be4f8-bae3-48fd-8b91-c57b71b3b0b1)
즐겨찾기 그룹 리스트가 해당 프로필 사용자로 조회되고, 내 프로필이 아닐 시 그룹 추가 버튼 삭제, 메뉴 버튼 삭제

![image](https://github.com/user-attachments/assets/dbab6c01-1993-4df2-a2af-6f71f36b7929)
즐겨찾기 장소 리스트에서 다른 사용자 조회 시 메뉴 버튼 삭제

![image](https://github.com/user-attachments/assets/acc6ccb6-d1e0-4dca-8669-9912a7bffca0)
비로그인 시 핫플레이스 리스트 FallbackMessage "로그인이 필요합니다." 로 분기 처리

![image](https://github.com/user-attachments/assets/458578c7-c526-45ad-bcdb-17972267958e)
게시글 카카오톡 공유하기 기능과 공유 선택 관련 모달 구현

## ✅ 작업 체크리스트
- [x] console.log / 불필요한 주석 제거
- [x] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [x] 예외 케이스 고려
- [x] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->
npm run build 통과
작동 테스트


## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
즐겨찾기 리스트도 메뉴 버튼 안보이게 해야겠네요 금방 처리하겠습니다 ! (완료)

다행히 카카오톡 공유하기는 카카오 개발자 페이지에서 신청할 게 따로 없는 것 같습니다 !
대신 같이 전송될 사진이나 메세지는 기본에서 추가한게 없어서 설정하는 법만 좀 더 살펴보고 
다른 사이트 방식 참고해서 수정해보겠습니다