### PR TITLE
유저 근처 정보 받아올 때 access token 보내지 않도록 수정

### DIFF
--- a/src/lib/api/map.ts
+++ b/src/lib/api/map.ts
@@ -17,22 +17,29 @@ export const fetchPlaceList = async (
   const url = `/map/place?lat=${lat}&lng=${lng}&distanceKm=${distanceKm}`;
   return await client<PlaceListResponse>(url, {
     method: "GET",
+    needAuth: false,
   });
 };
 
-export const fetchPlaceDetail = async (placeId: number): Promise<PlaceDetailResponse> => {
+export const fetchPlaceDetail = async (
+  placeId: number,
+): Promise<PlaceDetailResponse> => {
   return await client<PlaceDetailResponse>(`/map/place/${placeId}`, {
     method: "GET",
   });
 };
 
-export const fetchGroupList = async (userId: number): Promise<GroupListResponse[]> => {
+export const fetchGroupList = async (
+  userId: number,
+): Promise<GroupListResponse[]> => {
   return await client<GroupListResponse[]>(`/group/user/${userId}/group`, {
     method: "GET",
   });
 };
 
-export const fetchFavoriteStatus = async (placeId: number): Promise<boolean> => {
+export const fetchFavoriteStatus = async (
+  placeId: number,
+): Promise<boolean> => {
   return await client<boolean>(`/favorite/check`, {
     method: "GET",
     params: {
@@ -41,7 +48,9 @@ export const fetchFavoriteStatus = async (placeId: number): Promise<boolean> => 
   });
 };
 
-export const fetchFavoritesByGroup = async (groupId: number): Promise<FavoriteListResponse[]> => {
+export const fetchFavoritesByGroup = async (
+  groupId: number,
+): Promise<FavoriteListResponse[]> => {
   return await client<FavoriteListResponse[]>(`/favorite/${groupId}/items`, {
     method: "GET",
   });
@@ -52,30 +61,36 @@ export const postAddGroup = async (groupName: string): Promise<string> => {
   return await client<string>(`/group`, {
     method: "POST",
     body: JSON.stringify({
-      groupName: groupName
-    })
+      groupName: groupName,
+    }),
   });
 };
 
-export const postAddFavorite = async (groupId: number, {
-  kakaoPlaceId,
-  memo,
-  placeName,
-  address,
-  lat,
-  lng,
-  category,
-}: FavoriteAddRequest): Promise<FavroiteAddResponse> => {
-  return await client<FavroiteAddResponse>(`/favorite/groups/${groupId}/favorites`, {
-    method: "POST",
-    body: JSON.stringify({
-      kakaoPlaceId : kakaoPlaceId,
-      memo: memo,
-      placeName: placeName,
-      address: address,
-      lat: lat,
-      lng: lng,
-      category: category,
-    }),
-  });
+export const postAddFavorite = async (
+  groupId: number,
+  {
+    kakaoPlaceId,
+    memo,
+    placeName,
+    address,
+    lat,
+    lng,
+    category,
+  }: FavoriteAddRequest,
+): Promise<FavroiteAddResponse> => {
+  return await client<FavroiteAddResponse>(
+    `/favorite/groups/${groupId}/favorites`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        kakaoPlaceId: kakaoPlaceId,
+        memo: memo,
+        placeName: placeName,
+        address: address,
+        lat: lat,
+        lng: lng,
+        category: category,
+      }),
+    },
+  );
 };


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약해주세요 -->
유저 근처 정보 받아올 때 access token 보내지 않도록 수정

## ✨ 주요 변경 사항
<!-- 어떤 기능을 구현/수정했는지 리스트로 작성해주세요 -->
- 홈에서 401 오류 발생해서 access token을 보내지않도록 수정했습니다.


## 🖼️ 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷, GIF 등을 첨부해주세요 -->



## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [ ] 변수명, 함수명 명확하게 작성
- [ ] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
<!-- 어떤 페이지에서, 어떤 액션으로 테스트했는지 구체적으로 작성해주세요 -->



## 💬 기타 참고 사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분이나 논의할 점, 고민한 내용 등 -->
