### PR TITLE
ref/model : 유저 메모 이미지+이름+메모 배치구조 개선

### DIFF
--- a/src/components/map/UserMemoCard.tsx
+++ b/src/components/map/UserMemoCard.tsx
@@ -30,7 +30,7 @@ export default function UserMemoCard({
           alt="프로필 이미지"
           width={44}
           height={44}
-          className="rounded-full object-cover w-full h-full"
+          className="rounded-full object-cover aspect-square w-full h-full"
         />
       </Link>
 

--- a/src/components/map/UserMemoCard.tsx
+++ b/src/components/map/UserMemoCard.tsx
@@ -19,28 +19,34 @@ export default function UserMemoCard({
   const { setPageGroupList } = useMapPageStore();
 
   return (
-    <li className="flex items-center hover:bg-gray100 transition p-1">
-      {/* 이미지 영역 */}
+    <li className="flex items-center justify-center gap-3 w-full hover:bg-gray100 transition p-2">
+      {/* 프로필 이미지 */}
       <Link
         href={`/profile/${userId}`}
-        className="flex items-center justify-center rounded-full w-11 h-11 border-2 border-gray200"
+        className="flex flex-shrink-0 w-11 h-11 border-2 border-gray200 rounded-full overflow-hidden"
       >
         <Image
           src={getProfileImageUrl(profileImage)}
           alt="프로필 이미지"
-          width={40}
-          height={40}
-          className="rounded-full border border-gray200 flex-shrink-0 h-auto"
+          width={44}
+          height={44}
+          className="rounded-full object-cover w-full h-full"
         />
       </Link>
-      <div className="items-center flex p-3 shadow-sm space-x-3">
+
+      {/* 닉네임 + 메모 */}
+      <div className="flex flex-col w-full">
         <button
           onClick={() => setPageGroupList(userId)}
-          className="font-bold text-base flex-shrink-0 text-left text-gray900 hover:underline focus:outline-none"
+          className="font-bold text-base text-gray900 hover:underline text-left break-words p-1"
         >
           {nickName}
         </button>
-        <span className="text-gray600">{memo}</span>
+        <div className="mt-1 bg-white shadow-sm rounded-md p-1">
+          <span className="text-gray600 break-words whitespace-pre-line text-sm">
+            {memo}
+          </span>
+        </div>
       </div>
     </li>
   );

--- a/src/components/map/UserMemoCard.tsx
+++ b/src/components/map/UserMemoCard.tsx
@@ -35,14 +35,14 @@ export default function UserMemoCard({
       </Link>
 
       {/* 닉네임 + 메모 */}
-      <div className="flex flex-col w-full">
+      <div className="flex flex-col w-full justify-center ">
         <button
           onClick={() => setPageGroupList(userId)}
-          className="font-bold text-base text-gray900 hover:underline text-left break-words p-1"
+          className="font-bold text-base text-gray900 hover:underline text-left break-words px-1"
         >
           {nickName}
         </button>
-        <div className="mt-1 bg-white shadow-sm rounded-md p-1">
+        <div className="mt-1 bg-white shadow-sm rounded-md px-1">
           <span className="text-gray600 break-words whitespace-pre-line text-sm">
             {memo}
           </span>


### PR DESCRIPTION
## 📌 작업 개요
- 유저 메모 이미지+이름+메모 배치구조 개선

## ✨ 주요 변경 사항
- 닉네임이 길 때 어색한 문제 UI 수정으로 개선

## 🖼️ 스크린샷 (선택)
- 기존의 UI
<img width="407" alt="image" src="https://github.com/user-attachments/assets/93a1c3e9-8764-4772-9f42-269184936ecb" />

- 개선된 UI
<img width="399" alt="image" src="https://github.com/user-attachments/assets/31a39a7f-49ad-41d1-8de5-6cfcceb1693b" />



## ✅ 작업 체크리스트
- [ ] console.log / 불필요한 주석 제거
- [ ] 변수명, 함수명 명확하게 작성
- [x] 동작 테스트 완료
- [ ] 예외 케이스 고려
- [ ] 반복 코드 함수로 분리


## 📂 테스트 방법
- npm run build 통과



## 💬 기타 참고 사항
- 커밋 이름이 fire인건 실수입니다! 양해바랍니다
